### PR TITLE
update paths when using Ananaconda

### DIFF
--- a/cmake/FindCython.cmake
+++ b/cmake/FindCython.cmake
@@ -28,7 +28,7 @@ find_package(Python 3.6)
 if(Python_Interpreter_FOUND)
   get_filename_component( _python_path ${Python_EXECUTABLE} PATH )
   find_program( CYTHON_EXECUTABLE
-      NAMES cython${Python_VERSION_MAJOR} cython-${Python_VERSION_MAJOR}.${Python_VERSION_MINOR} cython cython.bat
+    NAMES cython cython.bat cython${Python_VERSION_MAJOR} cython-${Python_VERSION_MAJOR}.${Python_VERSION_MINOR} cython3 
     HINTS ${_python_path}
     )
 else()
@@ -37,7 +37,8 @@ else()
     )
 endif()
 
-
+message( "The Python path is ${_python_path}")
+message( "The Cython Executable is ${CYTHON_EXECUTABLE}")
 include( FindPackageHandleStandardArgs )
 FIND_PACKAGE_HANDLE_STANDARD_ARGS( Cython REQUIRED_VARS CYTHON_EXECUTABLE )
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -81,6 +81,9 @@ In the build folder
 #On Linux
 > CXX=g++ cmake -DCMAKE_INSTALL_PREFIX=../install ../src/fringe
 
+# with anaconda (on Linux) 
+> CXX=g++ cmake -DCMAKE_INSTALL_PREFIX=../install ../src/fringe -DCMAKE_PREFIX_PATH=$CONDA_PREFIX
+
 #If "conda install gxx_linux-64 / clangxx_osx-64"
 > CXX=${CXX} cmake -DCMAKE_INSTALL_PREFIX=../install ../src/fringe
 

--- a/docs/install.md
+++ b/docs/install.md
@@ -99,3 +99,6 @@ export PYTHONPATH=$PYTHONPATH:path-to-install-folder/python
 
 export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:path-to-install-folder/lib
 ```
+If using within an Anaconda environment:
+export GDAL_DIR=base-anaconda-directory/envs/fringe/
+


### PR DESCRIPTION
- Change FindCython.cmake search order so that it finds the conda version of cython
- Add -DCMAKE_PREFIX_PATH=$CONDA_PREFIX to installation command when using anaconda
- Without these changes, Fringe can get the system versions of these two packages
- This PR fixes #9.