### PR TITLE
update install doc for Mac

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -76,7 +76,7 @@ In the build folder
 > cd build
 
 #On OSX
-> CXX=clang++ cmake -DCMAKE_INSTALL_PREFIX=../install ../src/fringe
+> CXX=clang++ cmake -DCMAKE_FIND_FRAMEWORK=NEVER -DCMAKE_INSTALL_PREFIX=../install ../src/fringe
 
 #On Linux
 > CXX=g++ cmake -DCMAKE_INSTALL_PREFIX=../install ../src/fringe


### PR DESCRIPTION
Minor update to installation on Mac. 

As recommended by @rtburns-jpl here: 

https://github.com/isce-framework/isce2/pull/136/files#diff-04c6e90faac2675aa89e2176d2eec7d8R324-R329

with -DCMAKE_FIND_FRAMEWORK=NEVER Cmake won't look for systemwide frameworks. This option seems to be very useful when using macports or conda.
 
