### PR TITLE
Enforce Armadillo version requirement

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,7 @@ set(CMAKE_CXX_STANDARD 11)
 FIND_PACKAGE(GDAL 3.0 REQUIRED)
 
 ###Find Armadillo
-FIND_PACKAGE(Armadillo REQUIRED)
+FIND_PACKAGE(Armadillo 8.100 REQUIRED)
 
 ###Find openmp
 find_package(OpenMP COMPONENTS CXX)


### PR DESCRIPTION
FRInGE uses arma::index_min, added in Armadillo version 8.100

Fixes #31