### PR TITLE
Proposed changes to hardcoded parameters during unwrapping

### DIFF
--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -76,7 +76,7 @@ FRInGE currently is focused on estimating wrapped phase time-series for PS and D
 To prepare unwrapping commands for each epoch of time-series run `unwrapStack.py`. This will write the unwrapping command to a shell script _run_unwrap.sh_.
 
 ```
-unwrapStack.py -s slcs -m Sequential/miniStacks/ -d Sequential/Datum_connection/ -M 15 -u 'unwrap_fringe.py -m snaphu'
+unwrapStack.py -s slcs -m Sequential/miniStacks/ -d Sequential/Datum_connection/ -M 15 -u 'unwrap_fringe.py' --unw_method snaphu
 ```
 
 Alternatively one may use `integratePS.py --unw_method snaphu` in previous step, which will write a shell script _run_unwrap_ps_ds.sh_ (recommended).

--- a/python/integratePS.py
+++ b/python/integratePS.py
@@ -274,8 +274,12 @@ def main(iargs=None):
             date_j = pair.split('-')[1]
             intName = os.path.join(inps.outDir, "{0}_{1}.int".format(date_i, date_j))
             unwName = os.path.join(unwDir, "{0}_{1}.unw".format(date_i, date_j))
-            cmd = "unwrap_fringe.py -m " + inps.unwrapMethod + " -i " + intName + " -c " + corName + " -o " + unwName + " -x " + inps.xmlFile
-            runf.write(cmd + "\n")
+            if inps.xmlFile is None:
+                cmd = "unwrap_fringe.py -m " + inps.unwrapMethod + " -i " + intName + " -c " + corName + " -o " + unwName
+                runf.write(cmd + "\n")
+            else:
+                cmd = "unwrap_fringe.py -m " + inps.unwrapMethod + " -i " + intName + " -c " + corName + " -o " + unwName + " -x " + inps.xmlFile
+                runf.write(cmd + "\n")
         runf.close()
 
     dsSLC = None

--- a/python/integratePS.py
+++ b/python/integratePS.py
@@ -44,7 +44,7 @@ def cmdLineParser(iargs = None):
 
     parser.add_argument('-u', '--unw_method', '--unwrap_method', type=str, dest='unwrapMethod', choices=('snaphu','phass'),
             help='phase unwrapping method. e.g., snaphu, phass. If enabled, a shell file "run_unwrap_ps_ds.sh" with unwrap command will be created.')
-    
+
     parser.add_argument('-x', '--xml_file', type=str, dest='xmlFile',
             required=False, help='path of reference xml file for unwrapping with snaphu')
 

--- a/python/integratePS.py
+++ b/python/integratePS.py
@@ -44,6 +44,9 @@ def cmdLineParser(iargs = None):
 
     parser.add_argument('-u', '--unw_method', '--unwrap_method', type=str, dest='unwrapMethod', choices=('snaphu','phass'),
             help='phase unwrapping method. e.g., snaphu, phass. If enabled, a shell file "run_unwrap_ps_ds.sh" with unwrap command will be created.')
+    
+    parser.add_argument('-x', '--xml_file', type=str, dest='xmlFile',
+            required=False, help='path of reference xml file for unwrapping with snaphu')
 
     return parser.parse_args()
 
@@ -271,7 +274,7 @@ def main(iargs=None):
             date_j = pair.split('-')[1]
             intName = os.path.join(inps.outDir, "{0}_{1}.int".format(date_i, date_j))
             unwName = os.path.join(unwDir, "{0}_{1}.unw".format(date_i, date_j))
-            cmd = "unwrap_fringe.py -m " + inps.unwrapMethod + " -i " + intName + " -c " + corName + " -o " + unwName
+            cmd = "unwrap_fringe.py -m " + inps.unwrapMethod + " -i " + intName + " -c " + corName + " -o " + unwName + " -x " + inps.xmlFile
             runf.write(cmd + "\n")
         runf.close()
 

--- a/python/unwrapStack.py
+++ b/python/unwrapStack.py
@@ -178,8 +178,12 @@ if __name__ == '__main__':
         print("coherence: ", coh) 
         print("adjusted output phase: ", output)
         print("*****************")
-        cmd = inps.unwrapperScript + " -m " + inps.unwrapMethod + " -i " + miniStackSlc + " -c " + coh + " -o " + output + " -x " + inps.xmlFile
-        runf.write(cmd + "\n") 
+        if inps.xmlFile is None:
+            cmd = inps.unwrapperScript + " -m " + inps.unwrapMethod + " -i " + miniStackSlc + " -c " + coh + " -o " + output
+            runf.write(cmd + "\n")
+        else:
+            cmd = inps.unwrapperScript + " -m " + inps.unwrapMethod + " -i " + miniStackSlc + " -c " + coh + " -o " + output + " -x " + inps.xmlFile
+            runf.write(cmd + "\n") 
 
     for k in datumDict.keys():
         print(k)
@@ -190,8 +194,12 @@ if __name__ == '__main__':
         print("coherence: ", coh)
         print("adjusted output phase: ", output)
         print("*****************")
-        cmd = inps.unwrapperScript + " -m " + inps.unwrapMethod + " -i " + datumSlc + " -c " + coh + " -o " + output + " -x " + inps.xmlFile
-        runf.write(cmd + "\n")
+        if inps.xmlFile is None:
+            cmd = inps.unwrapperScript + " -m " + inps.unwrapMethod + " -i " + datumSlc + " -c " + coh + " -o " + output
+            runf.write(cmd + "\n")
+        else:
+            cmd = inps.unwrapperScript + " -m " + inps.unwrapMethod + " -i " + datumSlc + " -c " + coh + " -o " + output + " -x " + inps.xmlFile
+            runf.write(cmd + "\n")
 
     runf.close()
  

--- a/python/unwrapStack.py
+++ b/python/unwrapStack.py
@@ -39,6 +39,9 @@ def cmdLineParser():
 
     parser.add_argument('--unw_method','--unwrap_method', type=str, dest='unwrapMethod',
             default='phass', choices=('snaphu','phass'), help='unwrap method.')
+    
+    parser.add_argument('-x', '--xml_file', type=str, dest='xmlFile',
+            required=False, help='path of reference xml file for unwrapping with snaphu')
 
     return parser.parse_args()
 
@@ -175,7 +178,7 @@ if __name__ == '__main__':
         print("coherence: ", coh) 
         print("adjusted output phase: ", output)
         print("*****************")
-        cmd = inps.unwrapperScript + " -m " + inps.unwrapMethod + " -i " + miniStackSlc + " -c " + coh + " -o " + output
+        cmd = inps.unwrapperScript + " -m " + inps.unwrapMethod + " -i " + miniStackSlc + " -c " + coh + " -o " + output + " -x " + inps.xmlFile
         runf.write(cmd + "\n") 
 
     for k in datumDict.keys():
@@ -187,7 +190,7 @@ if __name__ == '__main__':
         print("coherence: ", coh)
         print("adjusted output phase: ", output)
         print("*****************")
-        cmd = inps.unwrapperScript + " -m " + inps.unwrapMethod + " -i " + datumSlc + " -c " + coh + " -o " + output
+        cmd = inps.unwrapperScript + " -m " + inps.unwrapMethod + " -i " + datumSlc + " -c " + coh + " -o " + output + " -x " + inps.xmlFile
         runf.write(cmd + "\n")
 
     runf.close()

--- a/python/unwrap_fringe.py
+++ b/python/unwrap_fringe.py
@@ -53,7 +53,7 @@ def unwrap_phass(inps, length, width):
 
     write_xml(phass.outputFile, width, length, 1 , "FLOAT", "BIL")
     
-#Adapted code from unwrap.py in topsStack
+#Adapted code from unwrap.py and s1a_isce_utils.py in topsStack
 def extractInfo(inps):
     
     '''
@@ -61,14 +61,11 @@ def extractInfo(inps):
     '''
     from isceobj.Planet.Planet import Planet
     from isceobj.Util.geo.ellipsoid import Ellipsoid
+    from iscesys.Component.ProductManager import ProductManager as PM
 
-   # with open(pckfile, 'rb') as f:
-   #    frame = pickle.load(f)
-
-    #with shelve.open(pckfile,flag='r') as db:
-    #    frame = db['swath']
-
-    frame = ut.loadProduct(inps.xmlFile)
+    pm = PM()
+    pm.configure
+    frame = pm.loadProduct(inps.xmlFile)
 
     burst = frame.bursts[0]
     planet = Planet(pname='Earth')
@@ -95,7 +92,6 @@ def extractInfo(inps):
 
     altitude   = llh[2]
 
-
     #sv = burst.orbit.interpolateOrbit(tmid, method='hermite')
     #pos = sv.getPosition()
     #llh = elp.ECEF(pos[0], pos[1], pos[2]).llh()
@@ -106,10 +102,10 @@ def extractInfo(inps):
     data['earthRadius'] = earthRadius  #elp.local_radius_of_curvature(llh.lat, hdg)
     return data
 
-def unwrap_snaphu(inps, length, width, metadata=metadata):
+def unwrap_snaphu(inps, length, width, metadata):
     from contrib.Snaphu.Snaphu import Snaphu
     
-    if metadata == {}:
+    if metadata is None:
         altitude = 800000.0
         earthRadius = 6371000.0
         wavelength = 0.056
@@ -181,9 +177,9 @@ if __name__ == '__main__':
         os.makedirs(unwrapDir)
 
     if inps.method == "snaphu":
-        metadata = extractInfo(inps)
+        if inps.xmlFile is not None:
+            metadata = extractInfo(inps)
         unwrap_snaphu(inps, length, width, metadata)
 
     elif inps.method == "phass":
         unwrap_phass(inps, length, width)
-

--- a/python/unwrap_fringe.py
+++ b/python/unwrap_fringe.py
@@ -64,7 +64,7 @@ def extractInfo(inps):
     from iscesys.Component.ProductManager import ProductManager as PM
 
     pm = PM()
-    pm.configure
+    #pm.configure
     frame = pm.loadProduct(inps.xmlFile)
 
     burst = frame.bursts[0]
@@ -75,7 +75,7 @@ def extractInfo(inps):
     data['wavelength'] = burst.radarWavelength
 
     tstart = frame.bursts[0].sensingStart
-    tend   = frame.bursts[-1].sensingStop
+    #tend   = frame.bursts[-1].sensingStop
     #tmid = tstart + 0.5*(tend - tstart)
     tmid = tstart
 

--- a/python/unwrap_fringe.py
+++ b/python/unwrap_fringe.py
@@ -107,8 +107,6 @@ def extractInfo(inps):
     return data
 
 def unwrap_snaphu(inps, length, width, metadata=metadata):
-    import isce
-    import isceobj
     from contrib.Snaphu.Snaphu import Snaphu
     
     if metadata == {}:

--- a/python/unwrap_fringe.py
+++ b/python/unwrap_fringe.py
@@ -104,22 +104,6 @@ def extractInfo(inps):
 
     #hdg = burst.orbit.getHeading()
     data['earthRadius'] = earthRadius  #elp.local_radius_of_curvature(llh.lat, hdg)
-    
-    #azspacing  = burst.azimuthTimeInterval * sv.getScalarVelocity()
-    #azres = 20.0 
-
-    #corrfile  = os.path.join(self._insar.mergedDirname, self._insar.coherenceFilename)
-    rangeLooks = inps.rglooks
-    azimuthLooks = inps.azlooks
-    azfact = 0.8
-    rngfact = 0.8
-
-    corrLooks = rangeLooks * azimuthLooks/(azfact*rngfact)
-
-    data['corrlooks'] = corrLooks  #inps.rglooks * inps.azlooks * azspacing / azres
-    data['rglooks'] = inps.rglooks
-    data['azlooks'] = inps.azlooks
-
     return data
 
 def unwrap_snaphu(inps, length, width, metadata=metadata):


### PR DESCRIPTION
- Changes are made to unwrap_fringe.py to incorporate parameters from xml files containing the wavelength, earthRadius and altitude values where the modifications where based from unwrap.py and s1a_isce_utils.py of topsStack
- Changes are made to integratePS.py and unwrapStack.py to write unwrapping scripts incorporating the xml file
- Changes in fringe/docs/workflow.md where the example code

`unwrapStack.py -s slcs -m Sequential/miniStacks/ -d Sequential/Datum_connection/ -M 15 -u 'unwrap_fringe.py -m snaphu'`

is changed to

`unwrapStack.py -s slcs -m Sequential/miniStacks/ -d Sequential/Datum_connection/ -M 15 -u 'unwrap_fringe.py' --unw_method snaphu` 

to remove the existence of two different unwrapping methods on the run_unwrap.sh.
