### PR TITLE
Fix tops2vrt script

### DIFF
--- a/python/tops2vrt.py
+++ b/python/tops2vrt.py
@@ -77,11 +77,11 @@ def getLinePixelBbox(geobbox, latFile, lonFile):
     se = lonlat2pixeline(lonFile, latFile, east, south)
     nw = lonlat2pixeline(lonFile, latFile, west, north)
 
-    ymin = np.int(np.round(np.min([se[1], nw[1]])))
-    ymax = np.int(np.round(np.max([se[1], nw[1]])))
+    ymin = int(np.round(np.min([se[1], nw[1]])))
+    ymax = int(np.round(np.max([se[1], nw[1]])))
 
-    xmin = np.int(np.round(np.min([se[0], nw[0]])))
-    xmax = np.int(np.round(np.max([se[0], nw[0]])))
+    xmin = int(np.round(np.min([se[0], nw[0]])))
+    xmax = int(np.round(np.max([se[0], nw[0]])))
 
     print("x min-max: ", xmin, xmax)
     print("y min-max: ", ymin, ymax)

--- a/python/tops2vrt.py
+++ b/python/tops2vrt.py
@@ -220,6 +220,9 @@ if __name__ == '__main__':
 
     print('write vrt file for geometry dataset')
     layers = ['lat', 'lon', 'hgt']
+
+    # Define pixel_offset variable (bytes)
+    pixel_offset = 8
     for ind, val in enumerate(layers):
         with open(os.path.join(inps.geomdir, val + '.vrt'), 'w') as fid:
             fid.write(vrttmpl.format(xsize=xsize, ysize=ysize,
@@ -230,4 +233,4 @@ if __name__ == '__main__':
                                          os.path.join(inps.indir,
                                                       'geom_reference',
                                                       val + '.rdr.full.vrt')),
-                                     linewidth=width * 8))
+                                     linewidth=width * pixel_offset))

--- a/python/tops2vrt.py
+++ b/python/tops2vrt.py
@@ -15,14 +15,11 @@ def cmdLineParse():
 
     parser = argparse.ArgumentParser(description='Tops SLC stack to VRT')
     parser.add_argument('-i', '--input', dest='indir', type=str,
-            required=True, help='Merged directory of tops stack generation')
+            required=True, help='Merged directory from ISCE2 Sentinel stack processor')
     parser.add_argument('-s', '--stack', dest='stackdir', type=str,
-            default='stack', help='Directory where the vrt stack will be stored (default is "stack")')
+            default='stack', help='Directory where the co-registered SLC stack VRT will be stored (default is "stack")')
     parser.add_argument('-g', '--geom', dest='geomdir', type=str,
-            default='geometry', help='Directory where the geometry vrts will be stored (default is "geometry")')
-    parser.add_argument('-c', '--slcs', dest='outdir', type=str,
-            default='slcs', help='Directory where the individual slc vrts will be stored (default is "slcs")')
-
+            default='geometry', help='Directory where the geometry VRTs will be stored (default is "geometry")')
     parser.add_argument('-b', '--bbox', dest='bbox', nargs=4, type=int, default=None, metavar=('Y0','Y1','X0','X1'),
             help='bounding box in row col: minLine maxLine minPixel maxPixel')
 

--- a/python/tops2vrt.py
+++ b/python/tops2vrt.py
@@ -19,6 +19,15 @@ def cmdLineParse():
     parser.add_argument('-i', '--input', dest='indir', type=str,
                         required=True,
                         help='Merged directory from ISCE2 Sentinel stack processor')
+    parser.add_argument('-S', '--slc_dir', dest='slc_dir', type=str,
+                        default='SLC',
+                        help='Name of the directory containing stack of SLCs (default: "SLC")')
+    parser.add_argument('-e', '--extension', dest='ext', type=str,
+                        default='slc.full.vrt',
+                        help='File extension of co-registered SLC files (default: "slc.full.vrt")')
+    parser.add_argument('-w', '--wavelength', dest='wavelength', type=float,
+                        default=0.05546576,
+                        help='Radar wavelenght for SLC stack (default: "0.05546576")')
     parser.add_argument('-s', '--stack', dest='stackdir', type=str,
                         default='stack',
                         help='Directory where the co-registered SLC stack VRT will be stored (default: "stack")')
@@ -107,7 +116,7 @@ if __name__ == '__main__':
     inps = cmdLineParse()
 
     # Get a list of co-registered full SLC VRTs
-    slclist = glob.glob(os.path.join(inps.indir, 'SLC', '*', '*.slc.full.vrt'))
+    slclist = glob.glob(os.path.join(inps.indir, inps.slc_dir, '*', f'*{inps.ext}'))
     num_slc = len(slclist)
 
     print('number of SLCs discovered: ', num_slc)
@@ -157,9 +166,6 @@ if __name__ == '__main__':
     slcs_base_file = os.path.join(inps.stackdir, 'slcs_base.vrt')
     print('write vrt file for stack directory')
 
-    # Allocate wavelength for Sentinel
-    wavelength = 0.05546576
-
     with open(slcs_base_file, 'w') as fid:
         fid.write(
             '<VRTDataset rasterXSize="{xsize}" rasterYSize="{ysize}">\n'.format(
@@ -186,7 +192,7 @@ if __name__ == '__main__':
                                  xmin=xmin, ymin=ymin,
                                  xsize=xsize, ysize=ysize,
                                  date=date, acq=date,
-                                 wvl=wavelength, index=ind + 1,
+                                 wvl=inps.wavelength, index=ind + 1,
                                  path=slc)
             fid.write(outstr)
 

--- a/python/tops2vrt.py
+++ b/python/tops2vrt.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
-import numpy as np 
-import os
 import glob
+import os
+
+import numpy as np
 from osgeo import gdal
 
 

--- a/python/tops2vrt.py
+++ b/python/tops2vrt.py
@@ -3,6 +3,7 @@
 
 import glob
 import os
+import sys
 
 import numpy as np
 from osgeo import gdal
@@ -120,8 +121,8 @@ if __name__ == '__main__':
         height = ds.RasterYSize
         ds = None
     else:
-        print('No SLC discovered. Stop and return')
-        return
+        # Exit program if no SLC VRT has been found
+        sys.exit('No SLC discovered. Stop and return')
 
     # Creating stack directory
     if os.path.exists(inps.stackdir):


### PR DESCRIPTION
The ISCE2 Sentinel stack processor generates a VRT file for each of the secondary co-registered SLC of the processed stack. Each VRT points to the individual bursts forming the single co-registered SLC.

At the moment, the script `tops2vrt.py` looks for the binary files of full/merged co-registered SLCs of the stack and tries to generate VRT files out of them. This step is not necessary, as the VRT generation for the full secondary co-registered SLCs is already taken into account by the ISCE2 Sentinel stack processor. Also, when `tops2vrt.py` looks for the binaries of the co-registered secondary SLCs, no SLC is found.

This PR removes the individual full-coregistered SLC VRT generation from `tops2vrt.py`. Instead,  the VRT stack file (`slcs_base.vrt`) is generated to directly pointing to the VRTs of the individual full-coregistered secondary SLCs generated by the ISCE2 stack processor. 

The PR also:
- Improves documentation
- Removes unused imports
- Format the code to abide by the pep8 notation

