### PR TITLE
Fix bug in unwrap_fringe.py

### DIFF
--- a/python/unwrap_fringe.py
+++ b/python/unwrap_fringe.py
@@ -179,6 +179,8 @@ if __name__ == '__main__':
     if inps.method == "snaphu":
         if inps.xmlFile is not None:
             metadata = extractInfo(inps)
+        else:
+            metadata = None
         unwrap_snaphu(inps, length, width, metadata)
 
     elif inps.method == "phass":


### PR DESCRIPTION
This PR should fix the bug in `unwrap_fringe.py`. Right now, `unwrap_fringe.py` will fails if using the SNAPHU unwrapper without the XML metadata file.

A fix is to set the `metadata` variable to None when no metadata XML file is found.

@bjmarfito @hfattahi 