### PR TITLE
Add "set -e" to run_unwrap_ps_ds.sh

### DIFF
--- a/python/integratePS.py
+++ b/python/integratePS.py
@@ -268,6 +268,7 @@ def main(iargs=None):
         # an output script with commands to unwrap interferograms
         run_outname = "run_unwrap_ps_ds.sh"
         runf= open(run_outname,'w')
+        runf.write("set -e\n")
 
         for pair in networkObj.pairsDates:
             date_i = pair.split('-')[0]


### PR DESCRIPTION
This let's you keyboard interrupt the unwrap script. Without the stop on error from `set -e`, you have to hold it while it tries to start each new snaphu process.