### PR TITLE
stripmap2vrt: adjust to geom_reference

### DIFF
--- a/python/stripmap2vrt.py
+++ b/python/stripmap2vrt.py
@@ -180,7 +180,7 @@ if __name__ == '__main__':
                                        xmin = xmin, ymin = ymin,
                                        width = width,
                                        height = height,
-                                       PATH = os.path.abspath( os.path.join(inps.indir, 'geom_master', val+'.rdr')),
+                                       PATH = os.path.abspath( os.path.join(inps.indir, 'geom_reference', val+'.rdr')),
                                        linewidth = width * 8))
 
 

--- a/python/tops2vrt.py
+++ b/python/tops2vrt.py
@@ -76,11 +76,11 @@ def getLinePixelBbox(geobbox, latFile, lonFile):
     se = lonlat2pixeline(lonFile, latFile, east, south)
     nw = lonlat2pixeline(lonFile, latFile, west, north)
 
-    ymin = np.int(np.round(np.min([se[1], nw[1]])))
-    ymax = np.int(np.round(np.max([se[1], nw[1]])))
+    ymin = np.int16(np.round(np.min([se[1], nw[1]])))
+    ymax = np.int16(np.round(np.max([se[1], nw[1]])))
 
-    xmin = np.int(np.round(np.min([se[0], nw[0]])))
-    xmax = np.int(np.round(np.max([se[0], nw[0]])))
+    xmin = np.int16(np.round(np.min([se[0], nw[0]])))
+    xmax = np.int16(np.round(np.max([se[0], nw[0]])))
 
     print("x min-max: ", xmin, xmax)
     print("y min-max: ", ymin, ymax)

--- a/python/unwrap_fringe.py
+++ b/python/unwrap_fringe.py
@@ -3,6 +3,7 @@
 # Author: Heresh Fattahi
 
 import os
+import time
 import argparse
 from osgeo import gdal
 import isce
@@ -26,7 +27,7 @@ def cmdLineParser():
 
     parser.add_argument('-m', '--method', type=str, dest='method',
             default='snaphu', help='unwrapping method: default = snaphu')
-    
+
     parser.add_argument('-x', '--xml_file', type=str, dest='xmlFile',
             required=False, help='path of reference xml file for unwrapping with snaphu')
 
@@ -52,10 +53,10 @@ def unwrap_phass(inps, length, width):
     phass.unwrap()
 
     write_xml(phass.outputFile, width, length, 1 , "FLOAT", "BIL")
-    
+
 #Adapted code from unwrap.py and s1a_isce_utils.py in topsStack
 def extractInfo(inps):
-    
+
     '''
     Extract required information from pickle file.
     '''
@@ -104,7 +105,7 @@ def extractInfo(inps):
 
 def unwrap_snaphu(inps, length, width, metadata):
     from contrib.Snaphu.Snaphu import Snaphu
-    
+
     if metadata is None:
         altitude = 800000.0
         earthRadius = 6371000.0
@@ -166,6 +167,8 @@ if __name__ == '__main__':
     '''
     Main driver.
     '''
+    start_time = time.time()
+
     #*************************************************************#
     # read the input options and unwrap
     inps = cmdLineParser()
@@ -185,3 +188,6 @@ if __name__ == '__main__':
 
     elif inps.method == "phass":
         unwrap_phass(inps, length, width)
+
+    m, s = divmod(time.time()-start_time, 60)
+    print('time used: {:02.0f} mins {:02.1f} secs.\n'.format(m, s))


### PR DESCRIPTION
This PR fix/add the following a few minor items:

+ `stripmap2vrt`: adjust to the new isce-2 convention of "geom_reference"

+ `tops2vrt`: fix `np.int()` deprecation warning

+ `unwrap_fringe`: add "used time" info