### PR TITLE
phase-link

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -27,3 +27,7 @@ add_subdirectory(timefn)
 
 #Add unwrapping error checks
 add_subdirectory(unwrap_error)
+
+#Add phase_link
+add_subdirectory(phase_link)
+

--- a/src/phase_link/CMakeLists.txt
+++ b/src/phase_link/CMakeLists.txt
@@ -1,0 +1,34 @@
+######Start of actual cmake part
+set(PHASELINK_SRCS    ../../include/fringe/ulongmask.hpp
+                ../../include/fringe/args.hxx
+                phase_link.hpp
+                phase_link.cpp)
+
+	set(PHASELINK_INCS    ../../include
+                ${ARMADILLO_INCLUDE_DIRS}
+                ${GDAL_INCLUDE_DIRS})
+
+	set(PHASELINK_LIBS    ${ARMADILLO_LIBRARIES}
+                ${GDAL_LIBRARIES}
+                ${LAPACK_LIBRARIES}
+                m)
+
+###Section for cython extension
+set_source_files_properties(
+    phase_linklib.pyx
+    PROPERTIES CYTHON_IS_CXX TRUE)
+cython_add_module(phase_linklib phase_linklib.pyx)
+target_include_directories(phase_linklib PUBLIC ${PHASELINK_INCS} .)
+target_link_libraries(phase_linklib PUBLIC ${PHASELINK_LIBS}) 
+target_link_libraries(phase_linklib PRIVATE OpenMP::OpenMP_CXX)
+
+###Final installation
+install (TARGETS
+        phase_linklib
+        DESTINATION ${FRINGE_PYDIR}
+        COMPONENT pylib)
+
+install(PROGRAMS
+    phase_link.py
+    DESTINATION ${FRINGE_BINDIR}
+    COMPONENT pyexec)

--- a/src/phase_link/phase_link.cpp
+++ b/src/phase_link/phase_link.cpp
@@ -1,0 +1,845 @@
+/**\file ampdispersion.c
+ * \author Piyush Agram.
+ *  */
+
+#include "phase_link.hpp"
+#include "gdal.h"
+#include "gdal_priv.h"
+#include "cpl_conv.h"
+#include "cpl_port.h"
+#include "fringe/fringe_common.hpp"
+#include "fringe/EigenLapack.hpp"
+
+#include <vector>
+#include <armadillo>
+
+int evd_process(evdOptions *opts)
+{
+
+    //Print user options to screen
+    opts->print();
+
+
+    int cols, rows, nbands;
+    int blockysize, boxesperblock;
+    int miniStackCount = opts->miniStackCount;
+    int minNeighbors = opts->minNeighbors;
+
+    //First thing to do is to read dimenions.
+    GDALDataset* inDataset = NULL;          //Input stack
+    GDALDataset* wtsDataset = NULL;         //Input weights
+    GDALDataset* corrDataset = NULL;        //Output correlation dataset
+    GDALDataset* compDataset = NULL;        //Compressed SLC dataset
+    std::vector<GDALDataset*> outDataset;   //Vector of output SLCs
+    
+    //Vector of dates for internal bookkeeping
+    std::vector<std::string> dates;
+
+    //Clock variables
+    double t_start, t_end;
+
+    //Make sure C++11 is being used
+    //unsigned int - 32 bytes
+    checkLongSetting();
+
+    //Register GDAL drivers
+    GDALAllRegister();
+
+    //Determine the number of uint32 bytes needed to store weights
+    int numAround = (2*opts->Ny + 1) * (2*opts->Nx + 1); 
+    int nulong = ceil( (numAround*1.0)/ 32.0);
+    std::cout << "Number of uint32 bytes for mask: " << nulong << "\n";
+
+    //Open the stack dataset
+    inDataset = reinterpret_cast<GDALDataset *>( GDALOpenShared( opts->inputDS.c_str(), GA_ReadOnly));
+    if (inDataset == NULL)
+    {
+        std::cout << "Cannot open stack file { " <<  opts->inputDS << " } with GDAL for reading. \n";
+
+        std::cout << "GDALOpen failed - " << opts->inputDS << "\n";
+        std::cout << "Exiting with error code .... (102) \n";
+        GDALDestroyDriverManager();
+        return 102;
+    }
+
+    cols = inDataset->GetRasterXSize();
+    rows = inDataset->GetRasterYSize();
+    nbands = inDataset->GetRasterCount();
+
+    std::cout << "Number of rows  = " << rows << "\n";
+    std::cout << "Number of cols  = " << cols << "\n";
+    std::cout << "Number of bands = " << nbands << "\n";
+
+
+    //Resolve method and bandwidth
+    if (opts->method.compare("STBAS") == 0)
+    {
+        //If bandwidth is not provided
+        if (opts->bandWidth <= 0)
+        {
+            std::cout << "Requested STBAS but no bandwidth provided \n";
+            GDALDestroyDriverManager();
+            return 101;
+        }
+        else if (opts->bandWidth >= (nbands-1))
+        {
+            std::cout <<"Requested STBAS bandwidth " 
+                      << opts->bandWidth << " is larger than full bandwidth " 
+                      << (nbands-1) << "\n";
+            GDALDestroyDriverManager();
+            return 101;
+        }
+    }
+
+    //Open weights file
+    wtsDataset = reinterpret_cast<GDALDataset *>( GDALOpenShared( opts->wtsDS.c_str(), GA_ReadOnly));
+    if (wtsDataset == NULL)
+    {
+        std::cout << "Could not open weights dataset {" << opts->wtsDS << "}\n";
+        std::cout << "Exiting with non-zero error code ... 105 \n";
+        GDALClose(inDataset);
+        GDALDestroyDriverManager();
+        return 105;
+    }
+
+    //Check for consistency between input and weight file
+    {
+        int code = 0;
+        int cc = wtsDataset->GetRasterXSize();
+        if (cc != cols)
+        {
+            std::cout << "Width mismatch between input dataset and weight dataset\n";
+            code = 106;
+        }
+
+        int rr = wtsDataset->GetRasterYSize();
+        if (rr != rows)
+        {
+            std::cout << "Length mismatch between input dataset and weight dataset \n";
+            code = 107;
+        }
+
+        int bb = wtsDataset->GetRasterCount();
+        if (bb != nulong)
+        {
+            std::cout << "Number of bands mismatch for weights and window size \n";
+            code = 108;
+        }
+
+        {
+            int inNx = ::atoi(wtsDataset->GetMetadataItem("HALFWINDOWX", "ENVI"));
+            int inNy = ::atoi(wtsDataset->GetMetadataItem("HALFWINDOWY", "ENVI"));
+
+            if (inNx != opts->Nx) 
+            {
+                std::cout << "Half window size x of wts is different from input. \n";
+                code = 109;
+            }
+
+            if (inNx == 0)
+            {
+                std::cout << "No non-zero metadata item called HALFWINDOWX \n";
+                code = 109;
+            }
+
+            if (inNy != opts->Ny)
+            {
+                std::cout << "Half window size y of wts is different from input. \n";
+                code = 110;
+            }
+
+            if (inNy == 0)
+            {
+                std::cout << "No non-zero metadata item called HALFWINDOWY \n";
+                code = 110;
+            }
+        }
+
+        if (code != 0)
+        {
+            std::cout <<"Exiting with error code ....("<<code<<")\n";
+            GDALClose(inDataset);
+            GDALClose(wtsDataset);
+            GDALDestroyDriverManager();
+
+            return code;
+        }
+    }
+
+
+    //Determine blocksizes
+    boxesperblock = int((opts->memsize * 1.0e6)/cols) / (opts->blocksize * (nbands*20+4+nulong)) ;
+    blockysize = boxesperblock * opts->blocksize;
+    if (blockysize < opts->blocksize)
+    {
+        blockysize = opts->blocksize;
+        boxesperblock = 1;
+    }
+
+    if (blockysize > rows)
+    {
+        blockysize = rows;
+        boxesperblock = 1;
+    }
+
+    std::cout << "Block size = " << blockysize << " lines \n";
+
+    int totalblocks = ceil( rows / (1.0 * blockysize));
+    std::cout << "Total number of blocks to process: " << totalblocks << "\n";
+
+    //Start the clock
+    t_start = getWallTime();
+
+    //Temporary array for reading in complex data
+    arma::cx_fmat cpxdata(cols*blockysize, nbands); //To store input data
+    arma::cx_fmat evddata(cols*blockysize, nbands);  //To store output data
+    arma::Mat<unsigned int> wts(nulong, cols*blockysize); //To store weights
+    arma::fvec corr(cols*blockysize);    //To store correlation
+    arma::cx_fvec comp(cols*blockysize); //To store compressed SLC
+
+    //Start block-by-block processing
+    int blockcount = 0;
+    int nthreads = 0;
+
+    //Resize vectors based on number of bands
+    outDataset.resize(nbands);
+    dates.resize(nbands);
+  
+    //Creation of output datasets
+    {
+        //Make sure that all the input stack layers have dates
+        for(int b=1; b<=nbands; b++)
+        {
+            const char* date = inDataset->GetRasterBand(b)->GetMetadataItem("Date", "slc");
+            if (strlen(date) != 8)
+            {
+                std::cout << "Band " << b << " does not appear to have Date information in slc metadata domain \n";
+                GDALClose(inDataset);
+                GDALClose(wtsDataset);
+                GDALDestroyDriverManager();
+
+                return 112;
+            }
+            dates[b-1] =  std::string(date);
+        }
+
+        //Check output folder
+        VSIStatBufL sStat;
+
+        //If folder already exists
+        if ( VSIStatExL( opts->outputFolder.c_str(), &sStat, VSI_STAT_EXISTS_FLAG | VSI_STAT_NATURE_FLAG) == 0)
+        {
+            if ( VSI_ISDIR(sStat.st_mode) )
+            {
+                std::cout << "Output folder : " << opts->outputFolder << " already exists \n";
+                std::cout << "Returning without processing. Clean up output folder and rerun.. \n";
+                GDALClose(inDataset);
+                GDALClose(wtsDataset);
+                GDALDestroyDriverManager();
+
+                return 113;
+            }
+            else
+            {
+                std::cout << opts->outputFolder << " already exists and appears to be a file on disk. \n";
+                std::cout << "Returning without processing. Clean up output folder and rerun.. \n";
+                GDALClose(inDataset);
+                GDALClose(wtsDataset);
+                GDALDestroyDriverManager();
+
+                return 114;
+            }
+        }
+
+        //Create output folder
+        if (VSIMkdir( opts->outputFolder.c_str(), 0777) != 0)
+        {
+            std::cout << "Could not create output folder: " << opts->outputFolder << "\n";
+
+            GDALClose(inDataset);
+            GDALClose(wtsDataset);
+            GDALDestroyDriverManager();
+            return 115;
+        }
+        std::cout << "Created output folder: " << opts->outputFolder << "\n";
+
+        //Creation of output dataset 
+        for(int b=1; b<=nbands; b++)
+        {
+            GDALDriver *poDriver = (GDALDriver*) GDALGetDriverByName("ENVI"); 
+            char **mOptions = NULL;
+            mOptions = CSLSetNameValue(mOptions, "INTERLEAVE", "BIP");
+            mOptions = CSLSetNameValue(mOptions, "SUFFIX", "ADD");
+
+            const char* fname = CPLStrdup(CPLFormFilename(opts->outputFolder.c_str(), dates[b-1].c_str(), ".slc"));
+            std::cout << "Input: " << fname <<  " " << strlen(fname) <<  "\n";
+
+            GDALDataset *temp = (GDALDataset*) poDriver->Create(fname, cols, rows, 1, GDT_CFloat32, mOptions);
+
+            if (temp == NULL)
+            {
+                std::cout << "Could not create output SLC: " << fname << "\n";
+                std::cout << "Exiting with non-zero error code ... 116 \n";
+
+                GDALClose(inDataset);
+                GDALClose(wtsDataset);
+
+                for (int j=0; j < b-1; j++)
+                {
+                    GDALClose(outDataset[j]);
+                }
+                GDALDestroyDriverManager();
+
+                return 116;
+            }
+
+            outDataset[b-1] = temp;
+
+            std::cout << "Created : " << fname  <<  "  " << temp << "\n";
+            
+            CSLDestroy(mOptions);
+        }
+
+
+        //Temporal coherence
+        {
+            GDALDriver *poDriver = (GDALDriver*) GDALGetDriverByName("ENVI"); 
+            char **mOptions = NULL;
+            mOptions = CSLSetNameValue(mOptions, "INTERLEAVE", "BIP");
+            mOptions = CSLSetNameValue(mOptions, "SUFFIX", "ADD");
+
+            const char* fname = CPLStrdup(CPLFormFilename(opts->outputFolder.c_str(), "tcorr.bin", NULL));
+
+            std::cout << "Corr: " << fname <<  " " << strlen(fname) << "\n";
+            corrDataset = (GDALDataset*) poDriver->Create(fname, cols, rows, 1, GDT_Float32, mOptions);
+
+            if (corrDataset == NULL)
+            {
+                std::cout << "Could not create temporal correlation file: " << fname << "\n";
+                std::cout << "Exiting with non-zero error code ... 117 \n";
+
+                GDALClose(inDataset);
+                GDALClose(wtsDataset);
+
+                for (int j=0; j<nbands; j++)
+                {
+                    GDALClose(outDataset[j]);
+                }
+                GDALDestroyDriverManager();
+                return 117;
+            }
+
+            std::cout << "Created : " << fname << " " << corrDataset << "\n";
+
+            CSLDestroy(mOptions);
+        }
+
+        //Compressed SLC
+        {
+            GDALDriver *poDriver = (GDALDriver*) GDALGetDriverByName("ENVI");
+            char **mOptions = NULL;
+            mOptions = CSLSetNameValue(mOptions, "INTERLEAVE", "BIP");
+            mOptions = CSLSetNameValue(mOptions, "SUFFIX", "ADD");
+
+            const char* fname = CPLStrdup(CPLFormFilename(opts->outputCompressedSlcFolder.c_str(), opts->compSlc.c_str(), NULL));
+
+            std::cout << "Compressed SLC: " << fname <<  " " << strlen(fname) << "\n";
+            compDataset = (GDALDataset*) poDriver->Create(fname, cols, rows, 1, GDT_CFloat32, mOptions);
+
+            if (compDataset == NULL)
+            {
+                std::cout << "Could not create compressed SLC file: " << fname << "\n";
+                std::cout << "Exiting with non-zero error code ... 117 \n";
+
+                GDALClose(inDataset);
+                GDALClose(wtsDataset);
+                GDALClose(corrDataset);
+                for (int j=0; j<nbands; j++)
+                {
+                    GDALClose(outDataset[j]);
+                }
+                GDALDestroyDriverManager();
+                return 117;
+            }
+
+            std::cout << "Created : " << fname << " " << compDataset << "\n";
+            CSLDestroy(mOptions);
+        }
+
+
+
+    }
+
+    nthreads = numberOfThreads();
+
+    //Useful variables
+    int Ny = opts->Ny;
+    int Nx = opts->Nx;
+    int Wy = 2*Ny+1;
+    int Wx = 2*Nx+1;
+    
+    const Ulongmask bitmask = {Ny,Nx};
+    
+    //Setup the Eigen Value workers
+    EVWorker *workers = new EVWorker[nthreads];
+    for(int ii=0; ii < nthreads; ii++)
+    {
+        workers[ii].prepare(nbands);
+    }
+
+    //Setup arrays for computing coherence matrix
+    arma::cx_cube Numer(nbands, nbands, nthreads);
+    arma::cx_cube Amp1(nbands, nbands, nthreads);
+    arma::cx_cube Amp2(nbands,nbands, nthreads);
+    arma::cx_cube Covar(nbands, nbands, nthreads);
+
+
+    //Block-by-block processing
+    int yoff = 0;
+
+    while( yoff < rows)
+    {
+        //Increment block counter
+        blockcount++;
+
+
+        int inysize = blockysize;
+
+        //Number of lines to read for the block
+        if ((yoff+inysize) > rows)
+            inysize = rows - yoff;
+
+//        std::cout << "Block " << blockcount << ": " << inysize << " lines \n";
+
+        //Block logic
+        int firstlinetowrite;
+        int linestowrite;
+        int rollback;
+
+        //For first block include the top half window.
+        if (blockcount == 1)
+        {
+            firstlinetowrite = 0;
+            linestowrite = inysize - Ny;
+            rollback = Ny;
+        
+            if( (yoff+blockysize) >= rows) //There is only one block, write the whole thing
+            {
+                linestowrite = inysize;
+                rollback = 0;
+            }
+
+        }
+        else if( (yoff+blockysize) >= rows) //Last block. Write bottom half window.
+        {
+            firstlinetowrite = Ny;
+            linestowrite = inysize-Ny;
+            rollback = 0;
+        }
+        else
+        {
+            firstlinetowrite = Ny;
+            linestowrite = inysize-2*Ny;
+            rollback = 0;
+        }
+
+
+        //Init to zeros for each block
+        cpxdata.zeros();
+        evddata.zeros();
+        wts.zeros();
+        Numer.zeros();
+        Amp1.zeros();
+        Amp2.zeros();
+        corr.zeros();
+        comp.zeros();
+        
+        //Read in data from all SLCs
+        for(int bb=0; bb < nbands; bb++)
+        {
+            int status = inDataset->GetRasterBand(bb+1)->RasterIO( GF_Read,
+                        0, yoff,   
+                        cols, inysize,
+                        (void*) (cpxdata.colptr(bb)), 
+                        cols, inysize, GDT_CFloat32,
+                        sizeof(std::complex<float>),
+                        sizeof(std::complex<float>)*cols, NULL);
+
+            if (status != 0)
+            {
+                std::cout << "Error reading data from band " << bb+1 << " at line " 
+                    << yoff << "\n";
+                std::cout << "Exiting with error code .... (118) \n";
+                GDALClose(inDataset);
+                GDALClose(wtsDataset);
+                for(int jj=0; jj<nbands; jj++) GDALClose(outDataset[jj]);
+                GDALClose(corrDataset);
+                GDALClose(compDataset);
+                GDALDestroyDriverManager();
+                return 118;
+            }
+        }
+
+        {
+            //Read in the weights dataset
+            int status =  wtsDataset->RasterIO(GF_Read,
+                    0, yoff,
+                    cols, inysize,
+                    (void*) (wts.memptr()),
+                    cols, inysize, GDT_UInt32,
+                    nulong, NULL,
+                    4*nulong, 4*nulong*cols,
+                    4, NULL);
+            if (status != 0)
+            {
+                std::cout << "Error reading weights at line " << yoff << "\n";
+                std::cout << "Exiting with error code .... (119) \n";
+                GDALClose(inDataset);
+                GDALClose(wtsDataset);
+                GDALClose(corrDataset);
+                GDALClose(compDataset);
+                for (int jj=0; jj<nbands; jj++) GDALClose(outDataset[jj]);
+                GDALDestroyDriverManager();
+                return 119;
+            }
+        }
+
+        //Copy method to constant string
+        const std::string method = opts->method;
+        const int BW = opts->bandWidth;
+        const bool isstbas = (method.compare("STBAS") == 0);
+        const bool ismle = (method.compare("MLE") == 0);
+
+    #pragma omp parallel for\
+        default(shared)
+        for(int pp=(firstlinetowrite*cols); pp < ((firstlinetowrite+linestowrite)*cols); pp++)
+        {
+            unsigned int *cenptr = wts.colptr(pp);
+            if (bitmask.getbit(cenptr,0,0) == 0) continue;
+
+            //Get thread number
+            int threadnum = omp_get_thread_num();
+
+            Covar.slice(threadnum).zeros();
+            Numer.slice(threadnum).zeros();
+            Amp1.slice(threadnum).zeros();
+            Amp2.slice(threadnum).zeros();
+
+            int cenii = pp/cols;
+            int cenjj = pp%cols;
+
+            int xmin = std::max(cenjj-Nx, 0);
+            int xmax = std::min(cols-1, cenjj+Nx);
+
+            int ymin = std::max(cenii-Ny, 0);
+            int ymax = std::min(inysize-1, cenii+Ny);
+
+
+            //Gather data
+            int npix = 0;
+            for (int ii=ymin; ii <=ymax; ii++)
+            {
+                for (int jj=xmin; jj <= xmax; jj++)
+                {
+
+                    if (bitmask.getbit(cenptr, ii-cenii, jj-cenjj) != 0)
+                    {
+                        npix++;
+                        arma::cx_frowvec ptr = cpxdata.row(ii*cols + jj);
+
+                        //Compute correlation for top half of the matrix only
+                        for(int ti=0; ti < nbands; ti++)
+                        {
+                            for(int tj=ti+1; tj<nbands; tj++)
+                            {
+                                Numer.at(ti,tj,threadnum) += ptr[ti] * std::conj(ptr[tj]);
+                                Amp1.at(ti,tj,threadnum)  += std::complex<double>(std::pow(std::abs(ptr[ti]),2),0.);
+                                Amp2.at(ti,tj,threadnum)  += std::complex<double>(std::pow(std::abs(ptr[tj]),2),0.);
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (npix < minNeighbors) continue;     //Minimum number of neighbors
+
+            //Create coherence matrix - common to all methods
+            for (int ti=0; ti <nbands; ti++)
+            {
+                for(int tj=ti+1; tj< nbands; tj++)
+                {
+                    std::complex<double> val1 = Numer.at(ti,tj,threadnum);
+                    double a1 = Amp1.at(ti,tj,threadnum).real();
+                    double a2 = Amp2.at(ti,tj,threadnum).real();
+
+                    std::complex<double> res = val1 / std::sqrt(a1*a2);
+                    Covar.at(ti,tj,threadnum) = res;
+                    Covar.at(tj,ti,threadnum) = std::conj(res);
+                }
+                Covar.at(ti,ti,threadnum) = std::complex<double>(1.0, 0.0);
+            }
+
+	        // check the covariance matrix. Can we get smallest Eigenvalue. 
+	        Amp1.slice(threadnum) = Covar.slice(threadnum);
+
+                int status = workers[threadnum].smallestEigen(Amp1.slice_memptr(threadnum), false);
+                bool valid = true;
+                if (status != 0)
+                {
+                        corr[pp] = -1;
+                        valid = false;
+                }
+                if (!valid) continue;
+             
+
+                //Store absolute of Covariance (i.e., coherence) in Amp1
+                for (int ti=0; ti<nbands; ti++)
+                {
+                    for(int tj=ti+1; tj<nbands; tj++)
+                    {
+                        double coh = std::abs( Covar.at(ti,tj,threadnum));
+                        Amp1.at(ti,tj,threadnum) = std::complex<double>(coh, 0.0);
+                        Amp1.at(tj,ti,threadnum) = std::complex<double>(coh, 0.0);
+                    }
+                    Amp1.at(ti,ti,threadnum) = std::complex<double>(1.0, 0.0);
+                }
+
+                bool run_evd = false;
+                //Compute inverse of coherence if possible (i.e., if coherence is positive definite).
+                {
+                    //Copy coherence to Amp2
+                    Amp2.slice(threadnum) = Amp1.slice(threadnum);
+
+                    //Check if coherence is positive semi-definitei
+		    int status = workers[threadnum].positiveDefiniteInverse(Amp2.slice_memptr(threadnum));
+
+		    // if status !=0 
+		    //    Place holder to Regularize Coherence and try again to compute Coherence
+                    if (status !=0)
+                    {
+			//inverse of coherence matrix can not be computed. So we can not estimate mle
+			// turn the run_evd flag to true so that we continue with EVD estimation
+                        run_evd = true;
+                    }
+                }
+
+		if (!run_evd) {
+		    // MLE estimation
+                   //Perform Hadamard product of inverse of coherence and Covariance for MLE estimation
+                   Amp2.slice(threadnum) %= Covar.slice(threadnum);
+                   //Obtain the smallest eigen vector
+                
+                    int status = workers[threadnum].smallestEigen( Amp2.slice_memptr(threadnum), true);
+                    if (status != 0)
+                    {
+                        // if eigen value decomposition of inv(coh)*cov failed, then turn on the run_evd flag
+                        run_evd = true;
+                    }
+               }
+
+            
+	    if (run_evd)
+            {
+                //This is for EVD - which the estimated wrapped phase is
+                //the largest eigen vector of the correlation matrix
+               
+		bool valid = true;
+                //Obtain the largest eigen vector
+                {
+		    Amp1.slice(threadnum) = Covar.slice(threadnum);
+                    int status = workers[threadnum].largestEigen( Amp1.slice_memptr(threadnum), true);
+                    if (status != 0)
+                    {
+                        corr[pp] = -6;
+                        valid = false;
+                    }
+                }
+                if (!valid) continue;   //Skip updating evddata
+           
+            } //End of EVD
+
+
+            //If we have gotten this far, "eigvec" should contain the solution
+            //For MLE, its from smallestEigen and its largetstEigen for others
+            //Ensure first date of acquired SLCs is set to zero
+            {
+                std::complex<double> cJ(0.0, 1.0);
+                double ph0 = std::arg(workers[threadnum].eigvec[miniStackCount-1]);
+                for(int ii=0; ii < nbands; ii++)
+                {
+                    double res = std::arg(workers[threadnum].eigvec[ii]);
+                    evddata.at(pp, ii) = std::exp(cJ * (res - ph0));
+                }
+
+                //Ensure that the reference index is exactly 1 - i.e, phase 0
+                evddata.at(pp, miniStackCount-1) = std::complex<float>(1.0, 0.0);
+            }
+
+
+            //compress acquired SLCs of the stack.
+            //This is common to all methods
+            //For sequential approach previous compressed SLCs are excluded in the current compression
+            {
+                std::complex<double> sumcomp = 0.0;
+                for(int ii=miniStackCount-1; ii < nbands; ii++)
+                {
+                    sumcomp += cpxdata.at(pp, ii) * std::conj( evddata.at(pp,ii));
+                }
+                comp.at(pp) = sumcomp / (1.0 * (nbands - miniStackCount + 1));
+            }            
+            
+            //Temporal coherence estimation
+            //This is common to all methods
+            {
+                std::complex<double> tempcorr(0.0,0.0);
+                std::complex<double> cJ(0.0,1.0);
+                int counter = 0;
+                for(int ti=0; ti<nbands; ti++)
+                {
+                    int ulim = isstbas ? (ti+BW+1) : nbands;
+                    for(int tj=ti+1; tj<ulim; tj++)
+                    {
+                        int ind = ti + nbands * tj;
+                    
+                        tempcorr += std::exp(cJ * (std::arg(Covar.at(ti,tj,threadnum)) - std::arg( evddata.at(pp,ti)) + std::arg( evddata.at(pp,tj))));
+                        counter++;
+                    }
+                }
+                corr.at(pp) = std::abs(tempcorr) /(counter * 1.0);
+            }
+
+        }
+
+       
+        //Write the data to output bands
+        for(int ii=0; ii<nbands; ii++)
+        {
+            int status = outDataset[ii]->GetRasterBand(1)->RasterIO(GF_Write, 0, yoff+firstlinetowrite,
+                        cols, linestowrite,
+                        (void*) (evddata.colptr(ii) + firstlinetowrite*cols),
+                        cols, linestowrite, GDT_CFloat32,
+                        sizeof(std::complex<float>), sizeof(std::complex<float>)*cols, NULL);
+
+            if (status != 0)
+            {
+                std::cout << "Error writing EVD data at line " << yoff << " for band " << ii+1 << "\n";
+                std::cout << "Exiting with error code .... (120) \n";
+                GDALClose(inDataset);
+                GDALClose(wtsDataset);
+                GDALClose(corrDataset);
+                GDALClose(compDataset);
+                for(int jj=0; jj < nbands; jj++) GDALClose(outDataset[jj]);
+                GDALDestroyDriverManager();
+                return 120;
+            }
+        }
+
+        //Write the temporal correlation data
+        {
+            int status = corrDataset->GetRasterBand(1)->RasterIO(GF_Write, 0, yoff+firstlinetowrite,
+                    cols, linestowrite,
+                    (void*) (corr.memptr()+firstlinetowrite*cols),
+                    cols, linestowrite, GDT_Float32,
+                    sizeof(float), sizeof(float)*cols, NULL);
+
+            if (status != 0)
+            {
+                std::cout << "Error writing temporal correlation data at line " << yoff << "\n";
+                std::cout << "Exiting with error code .... (121) \n";
+                GDALClose(inDataset);
+                GDALClose(wtsDataset);
+                GDALClose(corrDataset);
+                GDALClose(compDataset);
+                for(int jj=0; jj<nbands; jj++) GDALClose(outDataset[jj]);
+                GDALDestroyDriverManager();
+                return 121;
+            }
+        }
+
+
+        //Write the compressed SLC data
+        {
+            int status = compDataset->GetRasterBand(1)->RasterIO(GF_Write, 0, yoff+firstlinetowrite,
+                    cols, linestowrite,
+                    (void*) (comp.memptr()+firstlinetowrite*cols),
+                    cols, linestowrite, GDT_CFloat32,
+                    sizeof(std::complex<float>), sizeof(std::complex<float>)*cols, NULL);
+
+            if (status != 0)
+            {
+                std::cout << "Error writing temporal correlation data at line " << yoff << "\n";
+                std::cout << "Exiting with error code .... (121) \n";
+                GDALClose(inDataset);
+                GDALClose(wtsDataset);
+                GDALClose(corrDataset);
+                GDALClose(compDataset);
+                for(int jj=0; jj<nbands; jj++) GDALClose(outDataset[jj]);
+                GDALDestroyDriverManager();
+                return 121;
+            }
+        }            
+
+
+        //Update the counter
+        if ((yoff+blockysize) < rows)
+        {
+            yoff += linestowrite - rollback;
+        }
+        else
+        {
+            yoff=rows;
+        }
+
+        GDALTermProgress( yoff/(1.0*rows), NULL, NULL);
+
+    }
+
+    //Free the workers
+    delete [] workers;
+
+    //Close the datasets
+    GDALClose(inDataset);
+    GDALClose(wtsDataset);
+    for (int b=0; b<nbands;b++)
+    {
+        GDALClose(outDataset[b]);
+    }
+    GDALClose(corrDataset);
+    GDALClose(compDataset);
+    return(0);
+       
+};
+
+
+
+/* Main driver*/
+int main(int  argc, const char *argv[] ) {
+
+    //Options  
+    evdOptions opts;
+    int status;
+
+    //Parse command line options
+    status = opts.initFromCmdLine(argc, argv);
+
+    if (status != 0)
+    {
+        std::cout << "Error parsing command line inputs \n";
+        std::cout << "Exiting with non-zero return code .... \n";
+        return (101);
+    }
+
+
+    //Execute 
+    status = evd_process(&opts);
+
+    if (status != 0)
+    {
+        std::cout << "Error processing calamp \n";
+        std::cout << "Exiting with non-zero return code ....\n";
+        return (status);
+    }
+
+    return(0);
+       
+};

--- a/src/phase_link/phase_link.cpp
+++ b/src/phase_link/phase_link.cpp
@@ -3,843 +3,780 @@
  *  */
 
 #include "phase_link.hpp"
-#include "gdal.h"
-#include "gdal_priv.h"
+
+#include <armadillo>
+#include <vector>
+
 #include "cpl_conv.h"
 #include "cpl_port.h"
-#include "fringe/fringe_common.hpp"
 #include "fringe/EigenLapack.hpp"
+#include "fringe/fringe_common.hpp"
+#include "gdal.h"
+#include "gdal_priv.h"
 
-#include <vector>
-#include <armadillo>
+int evd_process(evdOptions *opts) {
+  // Print user options to screen
+  opts->print();
 
-int evd_process(evdOptions *opts)
-{
+  int cols, rows, nbands;
+  int blockysize, boxesperblock;
+  int miniStackCount = opts->miniStackCount;
+  int minNeighbors = opts->minNeighbors;
 
-    //Print user options to screen
-    opts->print();
+  // First thing to do is to read dimenions.
+  GDALDataset *inDataset = NULL;          // Input stack
+  GDALDataset *wtsDataset = NULL;         // Input weights
+  GDALDataset *corrDataset = NULL;        // Output correlation dataset
+  GDALDataset *compDataset = NULL;        // Compressed SLC dataset
+  std::vector<GDALDataset *> outDataset;  // Vector of output SLCs
 
+  // Vector of dates for internal bookkeeping
+  std::vector<std::string> dates;
 
-    int cols, rows, nbands;
-    int blockysize, boxesperblock;
-    int miniStackCount = opts->miniStackCount;
-    int minNeighbors = opts->minNeighbors;
+  // Clock variables
+  double t_start, t_end;
 
-    //First thing to do is to read dimenions.
-    GDALDataset* inDataset = NULL;          //Input stack
-    GDALDataset* wtsDataset = NULL;         //Input weights
-    GDALDataset* corrDataset = NULL;        //Output correlation dataset
-    GDALDataset* compDataset = NULL;        //Compressed SLC dataset
-    std::vector<GDALDataset*> outDataset;   //Vector of output SLCs
-    
-    //Vector of dates for internal bookkeeping
-    std::vector<std::string> dates;
+  // Make sure C++11 is being used
+  // unsigned int - 32 bytes
+  checkLongSetting();
 
-    //Clock variables
-    double t_start, t_end;
+  // Register GDAL drivers
+  GDALAllRegister();
 
-    //Make sure C++11 is being used
-    //unsigned int - 32 bytes
-    checkLongSetting();
+  // Determine the number of uint32 bytes needed to store weights
+  int numAround = (2 * opts->Ny + 1) * (2 * opts->Nx + 1);
+  int nulong = ceil((numAround * 1.0) / 32.0);
+  std::cout << "Number of uint32 bytes for mask: " << nulong << "\n";
 
-    //Register GDAL drivers
-    GDALAllRegister();
+  // Open the stack dataset
+  inDataset = reinterpret_cast<GDALDataset *>(
+      GDALOpenShared(opts->inputDS.c_str(), GA_ReadOnly));
+  if (inDataset == NULL) {
+    std::cout << "Cannot open stack file { " << opts->inputDS
+              << " } with GDAL for reading. \n";
 
-    //Determine the number of uint32 bytes needed to store weights
-    int numAround = (2*opts->Ny + 1) * (2*opts->Nx + 1); 
-    int nulong = ceil( (numAround*1.0)/ 32.0);
-    std::cout << "Number of uint32 bytes for mask: " << nulong << "\n";
+    std::cout << "GDALOpen failed - " << opts->inputDS << "\n";
+    std::cout << "Exiting with error code .... (102) \n";
+    GDALDestroyDriverManager();
+    return 102;
+  }
 
-    //Open the stack dataset
-    inDataset = reinterpret_cast<GDALDataset *>( GDALOpenShared( opts->inputDS.c_str(), GA_ReadOnly));
-    if (inDataset == NULL)
-    {
-        std::cout << "Cannot open stack file { " <<  opts->inputDS << " } with GDAL for reading. \n";
+  cols = inDataset->GetRasterXSize();
+  rows = inDataset->GetRasterYSize();
+  nbands = inDataset->GetRasterCount();
 
-        std::cout << "GDALOpen failed - " << opts->inputDS << "\n";
-        std::cout << "Exiting with error code .... (102) \n";
-        GDALDestroyDriverManager();
-        return 102;
+  std::cout << "Number of rows  = " << rows << "\n";
+  std::cout << "Number of cols  = " << cols << "\n";
+  std::cout << "Number of bands = " << nbands << "\n";
+
+  // Resolve method and bandwidth
+  if (opts->method.compare("STBAS") == 0) {
+    // If bandwidth is not provided
+    if (opts->bandWidth <= 0) {
+      std::cout << "Requested STBAS but no bandwidth provided \n";
+      GDALDestroyDriverManager();
+      return 101;
+    } else if (opts->bandWidth >= (nbands - 1)) {
+      std::cout << "Requested STBAS bandwidth " << opts->bandWidth
+                << " is larger than full bandwidth " << (nbands - 1) << "\n";
+      GDALDestroyDriverManager();
+      return 101;
     }
-
-    cols = inDataset->GetRasterXSize();
-    rows = inDataset->GetRasterYSize();
-    nbands = inDataset->GetRasterCount();
-
-    std::cout << "Number of rows  = " << rows << "\n";
-    std::cout << "Number of cols  = " << cols << "\n";
-    std::cout << "Number of bands = " << nbands << "\n";
-
-
-    //Resolve method and bandwidth
-    if (opts->method.compare("STBAS") == 0)
-    {
-        //If bandwidth is not provided
-        if (opts->bandWidth <= 0)
-        {
-            std::cout << "Requested STBAS but no bandwidth provided \n";
-            GDALDestroyDriverManager();
-            return 101;
-        }
-        else if (opts->bandWidth >= (nbands-1))
-        {
-            std::cout <<"Requested STBAS bandwidth " 
-                      << opts->bandWidth << " is larger than full bandwidth " 
-                      << (nbands-1) << "\n";
-            GDALDestroyDriverManager();
-            return 101;
-        }
-    }
-
-    //Open weights file
-    wtsDataset = reinterpret_cast<GDALDataset *>( GDALOpenShared( opts->wtsDS.c_str(), GA_ReadOnly));
-    if (wtsDataset == NULL)
-    {
-        std::cout << "Could not open weights dataset {" << opts->wtsDS << "}\n";
-        std::cout << "Exiting with non-zero error code ... 105 \n";
-        GDALClose(inDataset);
-        GDALDestroyDriverManager();
-        return 105;
-    }
-
-    //Check for consistency between input and weight file
-    {
-        int code = 0;
-        int cc = wtsDataset->GetRasterXSize();
-        if (cc != cols)
-        {
-            std::cout << "Width mismatch between input dataset and weight dataset\n";
-            code = 106;
-        }
-
-        int rr = wtsDataset->GetRasterYSize();
-        if (rr != rows)
-        {
-            std::cout << "Length mismatch between input dataset and weight dataset \n";
-            code = 107;
-        }
-
-        int bb = wtsDataset->GetRasterCount();
-        if (bb != nulong)
-        {
-            std::cout << "Number of bands mismatch for weights and window size \n";
-            code = 108;
-        }
-
-        {
-            int inNx = ::atoi(wtsDataset->GetMetadataItem("HALFWINDOWX", "ENVI"));
-            int inNy = ::atoi(wtsDataset->GetMetadataItem("HALFWINDOWY", "ENVI"));
-
-            if (inNx != opts->Nx) 
-            {
-                std::cout << "Half window size x of wts is different from input. \n";
-                code = 109;
-            }
-
-            if (inNx == 0)
-            {
-                std::cout << "No non-zero metadata item called HALFWINDOWX \n";
-                code = 109;
-            }
-
-            if (inNy != opts->Ny)
-            {
-                std::cout << "Half window size y of wts is different from input. \n";
-                code = 110;
-            }
-
-            if (inNy == 0)
-            {
-                std::cout << "No non-zero metadata item called HALFWINDOWY \n";
-                code = 110;
-            }
-        }
-
-        if (code != 0)
-        {
-            std::cout <<"Exiting with error code ....("<<code<<")\n";
-            GDALClose(inDataset);
-            GDALClose(wtsDataset);
-            GDALDestroyDriverManager();
-
-            return code;
-        }
-    }
-
-
-    //Determine blocksizes
-    boxesperblock = int((opts->memsize * 1.0e6)/cols) / (opts->blocksize * (nbands*20+4+nulong)) ;
-    blockysize = boxesperblock * opts->blocksize;
-    if (blockysize < opts->blocksize)
-    {
-        blockysize = opts->blocksize;
-        boxesperblock = 1;
-    }
-
-    if (blockysize > rows)
-    {
-        blockysize = rows;
-        boxesperblock = 1;
-    }
-
-    std::cout << "Block size = " << blockysize << " lines \n";
-
-    int totalblocks = ceil( rows / (1.0 * blockysize));
-    std::cout << "Total number of blocks to process: " << totalblocks << "\n";
-
-    //Start the clock
-    t_start = getWallTime();
-
-    //Temporary array for reading in complex data
-    arma::cx_fmat cpxdata(cols*blockysize, nbands); //To store input data
-    arma::cx_fmat evddata(cols*blockysize, nbands);  //To store output data
-    arma::Mat<unsigned int> wts(nulong, cols*blockysize); //To store weights
-    arma::fvec corr(cols*blockysize);    //To store correlation
-    arma::cx_fvec comp(cols*blockysize); //To store compressed SLC
-
-    //Start block-by-block processing
-    int blockcount = 0;
-    int nthreads = 0;
-
-    //Resize vectors based on number of bands
-    outDataset.resize(nbands);
-    dates.resize(nbands);
-  
-    //Creation of output datasets
-    {
-        //Make sure that all the input stack layers have dates
-        for(int b=1; b<=nbands; b++)
-        {
-            const char* date = inDataset->GetRasterBand(b)->GetMetadataItem("Date", "slc");
-            if (strlen(date) != 8)
-            {
-                std::cout << "Band " << b << " does not appear to have Date information in slc metadata domain \n";
-                GDALClose(inDataset);
-                GDALClose(wtsDataset);
-                GDALDestroyDriverManager();
-
-                return 112;
-            }
-            dates[b-1] =  std::string(date);
-        }
-
-        //Check output folder
-        VSIStatBufL sStat;
-
-        //If folder already exists
-        if ( VSIStatExL( opts->outputFolder.c_str(), &sStat, VSI_STAT_EXISTS_FLAG | VSI_STAT_NATURE_FLAG) == 0)
-        {
-            if ( VSI_ISDIR(sStat.st_mode) )
-            {
-                std::cout << "Output folder : " << opts->outputFolder << " already exists \n";
-                std::cout << "Returning without processing. Clean up output folder and rerun.. \n";
-                GDALClose(inDataset);
-                GDALClose(wtsDataset);
-                GDALDestroyDriverManager();
-
-                return 113;
-            }
-            else
-            {
-                std::cout << opts->outputFolder << " already exists and appears to be a file on disk. \n";
-                std::cout << "Returning without processing. Clean up output folder and rerun.. \n";
-                GDALClose(inDataset);
-                GDALClose(wtsDataset);
-                GDALDestroyDriverManager();
-
-                return 114;
-            }
-        }
-
-        //Create output folder
-        if (VSIMkdir( opts->outputFolder.c_str(), 0777) != 0)
-        {
-            std::cout << "Could not create output folder: " << opts->outputFolder << "\n";
-
-            GDALClose(inDataset);
-            GDALClose(wtsDataset);
-            GDALDestroyDriverManager();
-            return 115;
-        }
-        std::cout << "Created output folder: " << opts->outputFolder << "\n";
-
-        //Creation of output dataset 
-        for(int b=1; b<=nbands; b++)
-        {
-            GDALDriver *poDriver = (GDALDriver*) GDALGetDriverByName("ENVI"); 
-            char **mOptions = NULL;
-            mOptions = CSLSetNameValue(mOptions, "INTERLEAVE", "BIP");
-            mOptions = CSLSetNameValue(mOptions, "SUFFIX", "ADD");
-
-            const char* fname = CPLStrdup(CPLFormFilename(opts->outputFolder.c_str(), dates[b-1].c_str(), ".slc"));
-            std::cout << "Input: " << fname <<  " " << strlen(fname) <<  "\n";
-
-            GDALDataset *temp = (GDALDataset*) poDriver->Create(fname, cols, rows, 1, GDT_CFloat32, mOptions);
-
-            if (temp == NULL)
-            {
-                std::cout << "Could not create output SLC: " << fname << "\n";
-                std::cout << "Exiting with non-zero error code ... 116 \n";
-
-                GDALClose(inDataset);
-                GDALClose(wtsDataset);
-
-                for (int j=0; j < b-1; j++)
-                {
-                    GDALClose(outDataset[j]);
-                }
-                GDALDestroyDriverManager();
-
-                return 116;
-            }
-
-            outDataset[b-1] = temp;
-
-            std::cout << "Created : " << fname  <<  "  " << temp << "\n";
-            
-            CSLDestroy(mOptions);
-        }
-
-
-        //Temporal coherence
-        {
-            GDALDriver *poDriver = (GDALDriver*) GDALGetDriverByName("ENVI"); 
-            char **mOptions = NULL;
-            mOptions = CSLSetNameValue(mOptions, "INTERLEAVE", "BIP");
-            mOptions = CSLSetNameValue(mOptions, "SUFFIX", "ADD");
-
-            const char* fname = CPLStrdup(CPLFormFilename(opts->outputFolder.c_str(), "tcorr.bin", NULL));
-
-            std::cout << "Corr: " << fname <<  " " << strlen(fname) << "\n";
-            corrDataset = (GDALDataset*) poDriver->Create(fname, cols, rows, 1, GDT_Float32, mOptions);
-
-            if (corrDataset == NULL)
-            {
-                std::cout << "Could not create temporal correlation file: " << fname << "\n";
-                std::cout << "Exiting with non-zero error code ... 117 \n";
-
-                GDALClose(inDataset);
-                GDALClose(wtsDataset);
-
-                for (int j=0; j<nbands; j++)
-                {
-                    GDALClose(outDataset[j]);
-                }
-                GDALDestroyDriverManager();
-                return 117;
-            }
-
-            std::cout << "Created : " << fname << " " << corrDataset << "\n";
-
-            CSLDestroy(mOptions);
-        }
-
-        //Compressed SLC
-        {
-            GDALDriver *poDriver = (GDALDriver*) GDALGetDriverByName("ENVI");
-            char **mOptions = NULL;
-            mOptions = CSLSetNameValue(mOptions, "INTERLEAVE", "BIP");
-            mOptions = CSLSetNameValue(mOptions, "SUFFIX", "ADD");
-
-            const char* fname = CPLStrdup(CPLFormFilename(opts->outputCompressedSlcFolder.c_str(), opts->compSlc.c_str(), NULL));
-
-            std::cout << "Compressed SLC: " << fname <<  " " << strlen(fname) << "\n";
-            compDataset = (GDALDataset*) poDriver->Create(fname, cols, rows, 1, GDT_CFloat32, mOptions);
-
-            if (compDataset == NULL)
-            {
-                std::cout << "Could not create compressed SLC file: " << fname << "\n";
-                std::cout << "Exiting with non-zero error code ... 117 \n";
-
-                GDALClose(inDataset);
-                GDALClose(wtsDataset);
-                GDALClose(corrDataset);
-                for (int j=0; j<nbands; j++)
-                {
-                    GDALClose(outDataset[j]);
-                }
-                GDALDestroyDriverManager();
-                return 117;
-            }
-
-            std::cout << "Created : " << fname << " " << compDataset << "\n";
-            CSLDestroy(mOptions);
-        }
-
-
-
-    }
-
-    nthreads = numberOfThreads();
-
-    //Useful variables
-    int Ny = opts->Ny;
-    int Nx = opts->Nx;
-    int Wy = 2*Ny+1;
-    int Wx = 2*Nx+1;
-    
-    const Ulongmask bitmask = {Ny,Nx};
-    
-    //Setup the Eigen Value workers
-    EVWorker *workers = new EVWorker[nthreads];
-    for(int ii=0; ii < nthreads; ii++)
-    {
-        workers[ii].prepare(nbands);
-    }
-
-    //Setup arrays for computing coherence matrix
-    arma::cx_cube Numer(nbands, nbands, nthreads);
-    arma::cx_cube Amp1(nbands, nbands, nthreads);
-    arma::cx_cube Amp2(nbands,nbands, nthreads);
-    arma::cx_cube Covar(nbands, nbands, nthreads);
-
-
-    //Block-by-block processing
-    int yoff = 0;
-
-    while( yoff < rows)
-    {
-        //Increment block counter
-        blockcount++;
-
-
-        int inysize = blockysize;
-
-        //Number of lines to read for the block
-        if ((yoff+inysize) > rows)
-            inysize = rows - yoff;
-
-//        std::cout << "Block " << blockcount << ": " << inysize << " lines \n";
-
-        //Block logic
-        int firstlinetowrite;
-        int linestowrite;
-        int rollback;
-
-        //For first block include the top half window.
-        if (blockcount == 1)
-        {
-            firstlinetowrite = 0;
-            linestowrite = inysize - Ny;
-            rollback = Ny;
-        
-            if( (yoff+blockysize) >= rows) //There is only one block, write the whole thing
-            {
-                linestowrite = inysize;
-                rollback = 0;
-            }
-
-        }
-        else if( (yoff+blockysize) >= rows) //Last block. Write bottom half window.
-        {
-            firstlinetowrite = Ny;
-            linestowrite = inysize-Ny;
-            rollback = 0;
-        }
-        else
-        {
-            firstlinetowrite = Ny;
-            linestowrite = inysize-2*Ny;
-            rollback = 0;
-        }
-
-
-        //Init to zeros for each block
-        cpxdata.zeros();
-        evddata.zeros();
-        wts.zeros();
-        Numer.zeros();
-        Amp1.zeros();
-        Amp2.zeros();
-        corr.zeros();
-        comp.zeros();
-        
-        //Read in data from all SLCs
-        for(int bb=0; bb < nbands; bb++)
-        {
-            int status = inDataset->GetRasterBand(bb+1)->RasterIO( GF_Read,
-                        0, yoff,   
-                        cols, inysize,
-                        (void*) (cpxdata.colptr(bb)), 
-                        cols, inysize, GDT_CFloat32,
-                        sizeof(std::complex<float>),
-                        sizeof(std::complex<float>)*cols, NULL);
-
-            if (status != 0)
-            {
-                std::cout << "Error reading data from band " << bb+1 << " at line " 
-                    << yoff << "\n";
-                std::cout << "Exiting with error code .... (118) \n";
-                GDALClose(inDataset);
-                GDALClose(wtsDataset);
-                for(int jj=0; jj<nbands; jj++) GDALClose(outDataset[jj]);
-                GDALClose(corrDataset);
-                GDALClose(compDataset);
-                GDALDestroyDriverManager();
-                return 118;
-            }
-        }
-
-        {
-            //Read in the weights dataset
-            int status =  wtsDataset->RasterIO(GF_Read,
-                    0, yoff,
-                    cols, inysize,
-                    (void*) (wts.memptr()),
-                    cols, inysize, GDT_UInt32,
-                    nulong, NULL,
-                    4*nulong, 4*nulong*cols,
-                    4, NULL);
-            if (status != 0)
-            {
-                std::cout << "Error reading weights at line " << yoff << "\n";
-                std::cout << "Exiting with error code .... (119) \n";
-                GDALClose(inDataset);
-                GDALClose(wtsDataset);
-                GDALClose(corrDataset);
-                GDALClose(compDataset);
-                for (int jj=0; jj<nbands; jj++) GDALClose(outDataset[jj]);
-                GDALDestroyDriverManager();
-                return 119;
-            }
-        }
-
-        //Copy method to constant string
-        const std::string method = opts->method;
-        const int BW = opts->bandWidth;
-        const bool isstbas = (method.compare("STBAS") == 0);
-        const bool ismle = (method.compare("MLE") == 0);
-
-    #pragma omp parallel for\
-        default(shared)
-        for(int pp=(firstlinetowrite*cols); pp < ((firstlinetowrite+linestowrite)*cols); pp++)
-        {
-            unsigned int *cenptr = wts.colptr(pp);
-            if (bitmask.getbit(cenptr,0,0) == 0) continue;
-
-            //Get thread number
-            int threadnum = omp_get_thread_num();
-
-            Covar.slice(threadnum).zeros();
-            Numer.slice(threadnum).zeros();
-            Amp1.slice(threadnum).zeros();
-            Amp2.slice(threadnum).zeros();
-
-            int cenii = pp/cols;
-            int cenjj = pp%cols;
-
-            int xmin = std::max(cenjj-Nx, 0);
-            int xmax = std::min(cols-1, cenjj+Nx);
-
-            int ymin = std::max(cenii-Ny, 0);
-            int ymax = std::min(inysize-1, cenii+Ny);
-
-
-            //Gather data
-            int npix = 0;
-            for (int ii=ymin; ii <=ymax; ii++)
-            {
-                for (int jj=xmin; jj <= xmax; jj++)
-                {
-
-                    if (bitmask.getbit(cenptr, ii-cenii, jj-cenjj) != 0)
-                    {
-                        npix++;
-                        arma::cx_frowvec ptr = cpxdata.row(ii*cols + jj);
-
-                        //Compute correlation for top half of the matrix only
-                        for(int ti=0; ti < nbands; ti++)
-                        {
-                            for(int tj=ti+1; tj<nbands; tj++)
-                            {
-                                Numer.at(ti,tj,threadnum) += ptr[ti] * std::conj(ptr[tj]);
-                                Amp1.at(ti,tj,threadnum)  += std::complex<double>(std::pow(std::abs(ptr[ti]),2),0.);
-                                Amp2.at(ti,tj,threadnum)  += std::complex<double>(std::pow(std::abs(ptr[tj]),2),0.);
-                            }
-                        }
-                    }
-                }
-            }
-
-            if (npix < minNeighbors) continue;     //Minimum number of neighbors
-
-            //Create coherence matrix - common to all methods
-            for (int ti=0; ti <nbands; ti++)
-            {
-                for(int tj=ti+1; tj< nbands; tj++)
-                {
-                    std::complex<double> val1 = Numer.at(ti,tj,threadnum);
-                    double a1 = Amp1.at(ti,tj,threadnum).real();
-                    double a2 = Amp2.at(ti,tj,threadnum).real();
-
-                    std::complex<double> res = val1 / std::sqrt(a1*a2);
-                    Covar.at(ti,tj,threadnum) = res;
-                    Covar.at(tj,ti,threadnum) = std::conj(res);
-                }
-                Covar.at(ti,ti,threadnum) = std::complex<double>(1.0, 0.0);
-            }
-
-	        // check the covariance matrix. Can we get smallest Eigenvalue. 
-	        Amp1.slice(threadnum) = Covar.slice(threadnum);
-
-                int status = workers[threadnum].smallestEigen(Amp1.slice_memptr(threadnum), false);
-                bool valid = true;
-                if (status != 0)
-                {
-                        corr[pp] = -1;
-                        valid = false;
-                }
-                if (!valid) continue;
-             
-
-                //Store absolute of Covariance (i.e., coherence) in Amp1
-                for (int ti=0; ti<nbands; ti++)
-                {
-                    for(int tj=ti+1; tj<nbands; tj++)
-                    {
-                        double coh = std::abs( Covar.at(ti,tj,threadnum));
-                        Amp1.at(ti,tj,threadnum) = std::complex<double>(coh, 0.0);
-                        Amp1.at(tj,ti,threadnum) = std::complex<double>(coh, 0.0);
-                    }
-                    Amp1.at(ti,ti,threadnum) = std::complex<double>(1.0, 0.0);
-                }
-
-                bool run_evd = false;
-                //Compute inverse of coherence if possible (i.e., if coherence is positive definite).
-                {
-                    //Copy coherence to Amp2
-                    Amp2.slice(threadnum) = Amp1.slice(threadnum);
-
-                    //Check if coherence is positive semi-definitei
-		    int status = workers[threadnum].positiveDefiniteInverse(Amp2.slice_memptr(threadnum));
-
-		    // if status !=0 
-		    //    Place holder to Regularize Coherence and try again to compute Coherence
-                    if (status !=0)
-                    {
-			//inverse of coherence matrix can not be computed. So we can not estimate mle
-			// turn the run_evd flag to true so that we continue with EVD estimation
-                        run_evd = true;
-                    }
-                }
-
-		if (!run_evd) {
-		    // MLE estimation
-                   //Perform Hadamard product of inverse of coherence and Covariance for MLE estimation
-                   Amp2.slice(threadnum) %= Covar.slice(threadnum);
-                   //Obtain the smallest eigen vector
-                
-                    int status = workers[threadnum].smallestEigen( Amp2.slice_memptr(threadnum), true);
-                    if (status != 0)
-                    {
-                        // if eigen value decomposition of inv(coh)*cov failed, then turn on the run_evd flag
-                        run_evd = true;
-                    }
-               }
-
-            
-	    if (run_evd)
-            {
-                //This is for EVD - which the estimated wrapped phase is
-                //the largest eigen vector of the correlation matrix
-               
-		bool valid = true;
-                //Obtain the largest eigen vector
-                {
-		    Amp1.slice(threadnum) = Covar.slice(threadnum);
-                    int status = workers[threadnum].largestEigen( Amp1.slice_memptr(threadnum), true);
-                    if (status != 0)
-                    {
-                        corr[pp] = -6;
-                        valid = false;
-                    }
-                }
-                if (!valid) continue;   //Skip updating evddata
-           
-            } //End of EVD
-
-
-            //If we have gotten this far, "eigvec" should contain the solution
-            //For MLE, its from smallestEigen and its largetstEigen for others
-            //Ensure first date of acquired SLCs is set to zero
-            {
-                std::complex<double> cJ(0.0, 1.0);
-                double ph0 = std::arg(workers[threadnum].eigvec[miniStackCount-1]);
-                for(int ii=0; ii < nbands; ii++)
-                {
-                    double res = std::arg(workers[threadnum].eigvec[ii]);
-                    evddata.at(pp, ii) = std::exp(cJ * (res - ph0));
-                }
-
-                //Ensure that the reference index is exactly 1 - i.e, phase 0
-                evddata.at(pp, miniStackCount-1) = std::complex<float>(1.0, 0.0);
-            }
-
-
-            //compress acquired SLCs of the stack.
-            //This is common to all methods
-            //For sequential approach previous compressed SLCs are excluded in the current compression
-            {
-                std::complex<double> sumcomp = 0.0;
-                for(int ii=miniStackCount-1; ii < nbands; ii++)
-                {
-                    sumcomp += cpxdata.at(pp, ii) * std::conj( evddata.at(pp,ii));
-                }
-                comp.at(pp) = sumcomp / (1.0 * (nbands - miniStackCount + 1));
-            }            
-            
-            //Temporal coherence estimation
-            //This is common to all methods
-            {
-                std::complex<double> tempcorr(0.0,0.0);
-                std::complex<double> cJ(0.0,1.0);
-                int counter = 0;
-                for(int ti=0; ti<nbands; ti++)
-                {
-                    int ulim = isstbas ? (ti+BW+1) : nbands;
-                    for(int tj=ti+1; tj<ulim; tj++)
-                    {
-                        int ind = ti + nbands * tj;
-                    
-                        tempcorr += std::exp(cJ * (std::arg(Covar.at(ti,tj,threadnum)) - std::arg( evddata.at(pp,ti)) + std::arg( evddata.at(pp,tj))));
-                        counter++;
-                    }
-                }
-                corr.at(pp) = std::abs(tempcorr) /(counter * 1.0);
-            }
-
-        }
-
-       
-        //Write the data to output bands
-        for(int ii=0; ii<nbands; ii++)
-        {
-            int status = outDataset[ii]->GetRasterBand(1)->RasterIO(GF_Write, 0, yoff+firstlinetowrite,
-                        cols, linestowrite,
-                        (void*) (evddata.colptr(ii) + firstlinetowrite*cols),
-                        cols, linestowrite, GDT_CFloat32,
-                        sizeof(std::complex<float>), sizeof(std::complex<float>)*cols, NULL);
-
-            if (status != 0)
-            {
-                std::cout << "Error writing EVD data at line " << yoff << " for band " << ii+1 << "\n";
-                std::cout << "Exiting with error code .... (120) \n";
-                GDALClose(inDataset);
-                GDALClose(wtsDataset);
-                GDALClose(corrDataset);
-                GDALClose(compDataset);
-                for(int jj=0; jj < nbands; jj++) GDALClose(outDataset[jj]);
-                GDALDestroyDriverManager();
-                return 120;
-            }
-        }
-
-        //Write the temporal correlation data
-        {
-            int status = corrDataset->GetRasterBand(1)->RasterIO(GF_Write, 0, yoff+firstlinetowrite,
-                    cols, linestowrite,
-                    (void*) (corr.memptr()+firstlinetowrite*cols),
-                    cols, linestowrite, GDT_Float32,
-                    sizeof(float), sizeof(float)*cols, NULL);
-
-            if (status != 0)
-            {
-                std::cout << "Error writing temporal correlation data at line " << yoff << "\n";
-                std::cout << "Exiting with error code .... (121) \n";
-                GDALClose(inDataset);
-                GDALClose(wtsDataset);
-                GDALClose(corrDataset);
-                GDALClose(compDataset);
-                for(int jj=0; jj<nbands; jj++) GDALClose(outDataset[jj]);
-                GDALDestroyDriverManager();
-                return 121;
-            }
-        }
-
-
-        //Write the compressed SLC data
-        {
-            int status = compDataset->GetRasterBand(1)->RasterIO(GF_Write, 0, yoff+firstlinetowrite,
-                    cols, linestowrite,
-                    (void*) (comp.memptr()+firstlinetowrite*cols),
-                    cols, linestowrite, GDT_CFloat32,
-                    sizeof(std::complex<float>), sizeof(std::complex<float>)*cols, NULL);
-
-            if (status != 0)
-            {
-                std::cout << "Error writing temporal correlation data at line " << yoff << "\n";
-                std::cout << "Exiting with error code .... (121) \n";
-                GDALClose(inDataset);
-                GDALClose(wtsDataset);
-                GDALClose(corrDataset);
-                GDALClose(compDataset);
-                for(int jj=0; jj<nbands; jj++) GDALClose(outDataset[jj]);
-                GDALDestroyDriverManager();
-                return 121;
-            }
-        }            
-
-
-        //Update the counter
-        if ((yoff+blockysize) < rows)
-        {
-            yoff += linestowrite - rollback;
-        }
-        else
-        {
-            yoff=rows;
-        }
-
-        GDALTermProgress( yoff/(1.0*rows), NULL, NULL);
-
-    }
-
-    //Free the workers
-    delete [] workers;
-
-    //Close the datasets
+  }
+
+  // Open weights file
+  wtsDataset = reinterpret_cast<GDALDataset *>(
+      GDALOpenShared(opts->wtsDS.c_str(), GA_ReadOnly));
+  if (wtsDataset == NULL) {
+    std::cout << "Could not open weights dataset {" << opts->wtsDS << "}\n";
+    std::cout << "Exiting with non-zero error code ... 105 \n";
     GDALClose(inDataset);
-    GDALClose(wtsDataset);
-    for (int b=0; b<nbands;b++)
-    {
-        GDALClose(outDataset[b]);
+    GDALDestroyDriverManager();
+    return 105;
+  }
+
+  // Check for consistency between input and weight file
+  {
+    int code = 0;
+    int cc = wtsDataset->GetRasterXSize();
+    if (cc != cols) {
+      std::cout << "Width mismatch between input dataset and weight dataset\n";
+      code = 106;
     }
-    GDALClose(corrDataset);
-    GDALClose(compDataset);
-    return(0);
-       
+
+    int rr = wtsDataset->GetRasterYSize();
+    if (rr != rows) {
+      std::cout
+          << "Length mismatch between input dataset and weight dataset \n";
+      code = 107;
+    }
+
+    int bb = wtsDataset->GetRasterCount();
+    if (bb != nulong) {
+      std::cout << "Number of bands mismatch for weights and window size \n";
+      code = 108;
+    }
+
+    {
+      int inNx = ::atoi(wtsDataset->GetMetadataItem("HALFWINDOWX", "ENVI"));
+      int inNy = ::atoi(wtsDataset->GetMetadataItem("HALFWINDOWY", "ENVI"));
+
+      if (inNx != opts->Nx) {
+        std::cout << "Half window size x of wts is different from input. \n";
+        code = 109;
+      }
+
+      if (inNx == 0) {
+        std::cout << "No non-zero metadata item called HALFWINDOWX \n";
+        code = 109;
+      }
+
+      if (inNy != opts->Ny) {
+        std::cout << "Half window size y of wts is different from input. \n";
+        code = 110;
+      }
+
+      if (inNy == 0) {
+        std::cout << "No non-zero metadata item called HALFWINDOWY \n";
+        code = 110;
+      }
+    }
+
+    if (code != 0) {
+      std::cout << "Exiting with error code ....(" << code << ")\n";
+      GDALClose(inDataset);
+      GDALClose(wtsDataset);
+      GDALDestroyDriverManager();
+
+      return code;
+    }
+  }
+
+  // Determine blocksizes
+  boxesperblock = int((opts->memsize * 1.0e6) / cols) /
+                  (opts->blocksize * (nbands * 20 + 4 + nulong));
+  blockysize = boxesperblock * opts->blocksize;
+  if (blockysize < opts->blocksize) {
+    blockysize = opts->blocksize;
+    boxesperblock = 1;
+  }
+
+  if (blockysize > rows) {
+    blockysize = rows;
+    boxesperblock = 1;
+  }
+
+  std::cout << "Block size = " << blockysize << " lines \n";
+
+  int totalblocks = ceil(rows / (1.0 * blockysize));
+  std::cout << "Total number of blocks to process: " << totalblocks << "\n";
+
+  // Start the clock
+  t_start = getWallTime();
+
+  // Temporary array for reading in complex data
+  arma::cx_fmat cpxdata(cols * blockysize, nbands);  // To store input data
+  arma::cx_fmat evddata(cols * blockysize, nbands);  // To store output data
+  arma::Mat<unsigned int> wts(nulong, cols * blockysize);  // To store weights
+  arma::fvec corr(cols * blockysize);     // To store correlation
+  arma::cx_fvec comp(cols * blockysize);  // To store compressed SLC
+
+  // Start block-by-block processing
+  int blockcount = 0;
+  int nthreads = 0;
+
+  // Resize vectors based on number of bands
+  outDataset.resize(nbands);
+  dates.resize(nbands);
+
+  // Creation of output datasets
+  {
+    // Make sure that all the input stack layers have dates
+    for (int b = 1; b <= nbands; b++) {
+      const char *date =
+          inDataset->GetRasterBand(b)->GetMetadataItem("Date", "slc");
+      if (strlen(date) != 8) {
+        std::cout << "Band " << b
+                  << " does not appear to have Date information in slc "
+                     "metadata domain \n";
+        GDALClose(inDataset);
+        GDALClose(wtsDataset);
+        GDALDestroyDriverManager();
+
+        return 112;
+      }
+      dates[b - 1] = std::string(date);
+    }
+
+    // Check output folder
+    VSIStatBufL sStat;
+
+    // If folder already exists
+    if (VSIStatExL(opts->outputFolder.c_str(), &sStat,
+                   VSI_STAT_EXISTS_FLAG | VSI_STAT_NATURE_FLAG) == 0) {
+      if (VSI_ISDIR(sStat.st_mode)) {
+        std::cout << "Output folder : " << opts->outputFolder
+                  << " already exists \n";
+        std::cout << "Returning without processing. Clean up output folder and "
+                     "rerun.. \n";
+        GDALClose(inDataset);
+        GDALClose(wtsDataset);
+        GDALDestroyDriverManager();
+
+        return 113;
+      } else {
+        std::cout << opts->outputFolder
+                  << " already exists and appears to be a file on disk. \n";
+        std::cout << "Returning without processing. Clean up output folder and "
+                     "rerun.. \n";
+        GDALClose(inDataset);
+        GDALClose(wtsDataset);
+        GDALDestroyDriverManager();
+
+        return 114;
+      }
+    }
+
+    // Create output folder
+    if (VSIMkdir(opts->outputFolder.c_str(), 0777) != 0) {
+      std::cout << "Could not create output folder: " << opts->outputFolder
+                << "\n";
+
+      GDALClose(inDataset);
+      GDALClose(wtsDataset);
+      GDALDestroyDriverManager();
+      return 115;
+    }
+    std::cout << "Created output folder: " << opts->outputFolder << "\n";
+
+    // Creation of output dataset
+    for (int b = 1; b <= nbands; b++) {
+      GDALDriver *poDriver = (GDALDriver *)GDALGetDriverByName("ENVI");
+      char **mOptions = NULL;
+      mOptions = CSLSetNameValue(mOptions, "INTERLEAVE", "BIP");
+      mOptions = CSLSetNameValue(mOptions, "SUFFIX", "ADD");
+
+      const char *fname = CPLStrdup(CPLFormFilename(
+          opts->outputFolder.c_str(), dates[b - 1].c_str(), ".slc"));
+      std::cout << "Input: " << fname << " " << strlen(fname) << "\n";
+
+      GDALDataset *temp = (GDALDataset *)poDriver->Create(
+          fname, cols, rows, 1, GDT_CFloat32, mOptions);
+
+      if (temp == NULL) {
+        std::cout << "Could not create output SLC: " << fname << "\n";
+        std::cout << "Exiting with non-zero error code ... 116 \n";
+
+        GDALClose(inDataset);
+        GDALClose(wtsDataset);
+
+        for (int j = 0; j < b - 1; j++) {
+          GDALClose(outDataset[j]);
+        }
+        GDALDestroyDriverManager();
+
+        return 116;
+      }
+
+      outDataset[b - 1] = temp;
+
+      std::cout << "Created : " << fname << "  " << temp << "\n";
+
+      CSLDestroy(mOptions);
+    }
+
+    // Temporal coherence
+    {
+      GDALDriver *poDriver = (GDALDriver *)GDALGetDriverByName("ENVI");
+      char **mOptions = NULL;
+      mOptions = CSLSetNameValue(mOptions, "INTERLEAVE", "BIP");
+      mOptions = CSLSetNameValue(mOptions, "SUFFIX", "ADD");
+
+      const char *fname = CPLStrdup(
+          CPLFormFilename(opts->outputFolder.c_str(), "tcorr.bin", NULL));
+
+      std::cout << "Corr: " << fname << " " << strlen(fname) << "\n";
+      corrDataset = (GDALDataset *)poDriver->Create(fname, cols, rows, 1,
+                                                    GDT_Float32, mOptions);
+
+      if (corrDataset == NULL) {
+        std::cout << "Could not create temporal correlation file: " << fname
+                  << "\n";
+        std::cout << "Exiting with non-zero error code ... 117 \n";
+
+        GDALClose(inDataset);
+        GDALClose(wtsDataset);
+
+        for (int j = 0; j < nbands; j++) {
+          GDALClose(outDataset[j]);
+        }
+        GDALDestroyDriverManager();
+        return 117;
+      }
+
+      std::cout << "Created : " << fname << " " << corrDataset << "\n";
+
+      CSLDestroy(mOptions);
+    }
+
+    // Compressed SLC
+    {
+      GDALDriver *poDriver = (GDALDriver *)GDALGetDriverByName("ENVI");
+      char **mOptions = NULL;
+      mOptions = CSLSetNameValue(mOptions, "INTERLEAVE", "BIP");
+      mOptions = CSLSetNameValue(mOptions, "SUFFIX", "ADD");
+
+      const char *fname =
+          CPLStrdup(CPLFormFilename(opts->outputCompressedSlcFolder.c_str(),
+                                    opts->compSlc.c_str(), NULL));
+
+      std::cout << "Compressed SLC: " << fname << " " << strlen(fname) << "\n";
+      compDataset = (GDALDataset *)poDriver->Create(fname, cols, rows, 1,
+                                                    GDT_CFloat32, mOptions);
+
+      if (compDataset == NULL) {
+        std::cout << "Could not create compressed SLC file: " << fname << "\n";
+        std::cout << "Exiting with non-zero error code ... 117 \n";
+
+        GDALClose(inDataset);
+        GDALClose(wtsDataset);
+        GDALClose(corrDataset);
+        for (int j = 0; j < nbands; j++) {
+          GDALClose(outDataset[j]);
+        }
+        GDALDestroyDriverManager();
+        return 117;
+      }
+
+      std::cout << "Created : " << fname << " " << compDataset << "\n";
+      CSLDestroy(mOptions);
+    }
+  }
+
+  nthreads = numberOfThreads();
+
+  // Useful variables
+  int Ny = opts->Ny;
+  int Nx = opts->Nx;
+  int Wy = 2 * Ny + 1;
+  int Wx = 2 * Nx + 1;
+
+  const Ulongmask bitmask = {Ny, Nx};
+
+  // Setup the Eigen Value workers
+  EVWorker *workers = new EVWorker[nthreads];
+  for (int ii = 0; ii < nthreads; ii++) {
+    workers[ii].prepare(nbands);
+  }
+
+  // Setup arrays for computing coherence matrix
+  arma::cx_cube Numer(nbands, nbands, nthreads);
+  arma::cx_cube Amp1(nbands, nbands, nthreads);
+  arma::cx_cube Amp2(nbands, nbands, nthreads);
+  arma::cx_cube Covar(nbands, nbands, nthreads);
+
+  // Block-by-block processing
+  int yoff = 0;
+
+  while (yoff < rows) {
+    // Increment block counter
+    blockcount++;
+
+    int inysize = blockysize;
+
+    // Number of lines to read for the block
+    if ((yoff + inysize) > rows) inysize = rows - yoff;
+
+    //        std::cout << "Block " << blockcount << ": " << inysize << " lines
+    //        \n";
+
+    // Block logic
+    int firstlinetowrite;
+    int linestowrite;
+    int rollback;
+
+    // For first block include the top half window.
+    if (blockcount == 1) {
+      firstlinetowrite = 0;
+      linestowrite = inysize - Ny;
+      rollback = Ny;
+
+      if ((yoff + blockysize) >=
+          rows)  // There is only one block, write the whole thing
+      {
+        linestowrite = inysize;
+        rollback = 0;
+      }
+
+    } else if ((yoff + blockysize) >=
+               rows)  // Last block. Write bottom half window.
+    {
+      firstlinetowrite = Ny;
+      linestowrite = inysize - Ny;
+      rollback = 0;
+    } else {
+      firstlinetowrite = Ny;
+      linestowrite = inysize - 2 * Ny;
+      rollback = 0;
+    }
+
+    // Init to zeros for each block
+    cpxdata.zeros();
+    evddata.zeros();
+    wts.zeros();
+    Numer.zeros();
+    Amp1.zeros();
+    Amp2.zeros();
+    corr.zeros();
+    comp.zeros();
+
+    // Read in data from all SLCs
+    for (int bb = 0; bb < nbands; bb++) {
+      int status = inDataset->GetRasterBand(bb + 1)->RasterIO(
+          GF_Read, 0, yoff, cols, inysize, (void *)(cpxdata.colptr(bb)), cols,
+          inysize, GDT_CFloat32, sizeof(std::complex<float>),
+          sizeof(std::complex<float>) * cols, NULL);
+
+      if (status != 0) {
+        std::cout << "Error reading data from band " << bb + 1 << " at line "
+                  << yoff << "\n";
+        std::cout << "Exiting with error code .... (118) \n";
+        GDALClose(inDataset);
+        GDALClose(wtsDataset);
+        for (int jj = 0; jj < nbands; jj++) GDALClose(outDataset[jj]);
+        GDALClose(corrDataset);
+        GDALClose(compDataset);
+        GDALDestroyDriverManager();
+        return 118;
+      }
+    }
+
+    {
+      // Read in the weights dataset
+      int status = wtsDataset->RasterIO(GF_Read, 0, yoff, cols, inysize,
+                                        (void *)(wts.memptr()), cols, inysize,
+                                        GDT_UInt32, nulong, NULL, 4 * nulong,
+                                        4 * nulong * cols, 4, NULL);
+      if (status != 0) {
+        std::cout << "Error reading weights at line " << yoff << "\n";
+        std::cout << "Exiting with error code .... (119) \n";
+        GDALClose(inDataset);
+        GDALClose(wtsDataset);
+        GDALClose(corrDataset);
+        GDALClose(compDataset);
+        for (int jj = 0; jj < nbands; jj++) GDALClose(outDataset[jj]);
+        GDALDestroyDriverManager();
+        return 119;
+      }
+    }
+
+    // Copy method to constant string
+    const std::string method = opts->method;
+    const int BW = opts->bandWidth;
+    const bool isstbas = (method.compare("STBAS") == 0);
+    const bool ismle = (method.compare("MLE") == 0);
+
+#pragma omp parallel for default(shared)
+    for (int pp = (firstlinetowrite * cols);
+         pp < ((firstlinetowrite + linestowrite) * cols); pp++) {
+      unsigned int *cenptr = wts.colptr(pp);
+      if (bitmask.getbit(cenptr, 0, 0) == 0) continue;
+
+      // Get thread number
+      int threadnum = omp_get_thread_num();
+
+      Covar.slice(threadnum).zeros();
+      Numer.slice(threadnum).zeros();
+      Amp1.slice(threadnum).zeros();
+      Amp2.slice(threadnum).zeros();
+
+      int cenii = pp / cols;
+      int cenjj = pp % cols;
+
+      int xmin = std::max(cenjj - Nx, 0);
+      int xmax = std::min(cols - 1, cenjj + Nx);
+
+      int ymin = std::max(cenii - Ny, 0);
+      int ymax = std::min(inysize - 1, cenii + Ny);
+
+      // Gather data
+      int npix = 0;
+      for (int ii = ymin; ii <= ymax; ii++) {
+        for (int jj = xmin; jj <= xmax; jj++) {
+          if (bitmask.getbit(cenptr, ii - cenii, jj - cenjj) != 0) {
+            npix++;
+            arma::cx_frowvec ptr = cpxdata.row(ii * cols + jj);
+
+            // Compute correlation for top half of the matrix only
+            for (int ti = 0; ti < nbands; ti++) {
+              for (int tj = ti + 1; tj < nbands; tj++) {
+                Numer.at(ti, tj, threadnum) += ptr[ti] * std::conj(ptr[tj]);
+                Amp1.at(ti, tj, threadnum) +=
+                    std::complex<double>(std::pow(std::abs(ptr[ti]), 2), 0.);
+                Amp2.at(ti, tj, threadnum) +=
+                    std::complex<double>(std::pow(std::abs(ptr[tj]), 2), 0.);
+              }
+            }
+          }
+        }
+      }
+
+      if (npix < minNeighbors) continue;  // Minimum number of neighbors
+
+      // Create coherence matrix - common to all methods
+      for (int ti = 0; ti < nbands; ti++) {
+        for (int tj = ti + 1; tj < nbands; tj++) {
+          std::complex<double> val1 = Numer.at(ti, tj, threadnum);
+          double a1 = Amp1.at(ti, tj, threadnum).real();
+          double a2 = Amp2.at(ti, tj, threadnum).real();
+
+          std::complex<double> res = val1 / std::sqrt(a1 * a2);
+          Covar.at(ti, tj, threadnum) = res;
+          Covar.at(tj, ti, threadnum) = std::conj(res);
+        }
+        Covar.at(ti, ti, threadnum) = std::complex<double>(1.0, 0.0);
+      }
+
+      // check the covariance matrix. Can we get smallest Eigenvalue.
+      Amp1.slice(threadnum) = Covar.slice(threadnum);
+
+      int status =
+          workers[threadnum].smallestEigen(Amp1.slice_memptr(threadnum), false);
+      bool valid = true;
+      if (status != 0) {
+        corr[pp] = -1;
+        valid = false;
+      }
+      if (!valid) continue;
+
+      // Store absolute of Covariance (i.e., coherence) in Amp1
+      for (int ti = 0; ti < nbands; ti++) {
+        for (int tj = ti + 1; tj < nbands; tj++) {
+          double coh = std::abs(Covar.at(ti, tj, threadnum));
+          Amp1.at(ti, tj, threadnum) = std::complex<double>(coh, 0.0);
+          Amp1.at(tj, ti, threadnum) = std::complex<double>(coh, 0.0);
+        }
+        Amp1.at(ti, ti, threadnum) = std::complex<double>(1.0, 0.0);
+      }
+
+      bool run_evd = false;
+      // Compute inverse of coherence if possible (i.e., if coherence is
+      // positive definite).
+      {
+        // Copy coherence to Amp2
+        Amp2.slice(threadnum) = Amp1.slice(threadnum);
+
+        // Check if coherence is positive semi-definitei
+        int status = workers[threadnum].positiveDefiniteInverse(
+            Amp2.slice_memptr(threadnum));
+
+        // if status !=0
+        //    Place holder to Regularize Coherence and try again to compute
+        //    Coherence
+        if (status != 0) {
+          // inverse of coherence matrix can not be computed. So we can not
+          // estimate mle
+          //  turn the run_evd flag to true so that we continue with EVD
+          //  estimation
+          run_evd = true;
+        }
+      }
+
+      if (!run_evd) {
+        // MLE estimation
+        // Perform Hadamard product of inverse of coherence and Covariance for
+        // MLE estimation
+        Amp2.slice(threadnum) %= Covar.slice(threadnum);
+        // Obtain the smallest eigen vector
+
+        int status = workers[threadnum].smallestEigen(
+            Amp2.slice_memptr(threadnum), true);
+        if (status != 0) {
+          // if eigen value decomposition of inv(coh)*cov failed, then turn on
+          // the run_evd flag
+          run_evd = true;
+        }
+      }
+
+      if (run_evd) {
+        // This is for EVD - which the estimated wrapped phase is
+        // the largest eigen vector of the correlation matrix
+
+        bool valid = true;
+        // Obtain the largest eigen vector
+        {
+          Amp1.slice(threadnum) = Covar.slice(threadnum);
+          int status = workers[threadnum].largestEigen(
+              Amp1.slice_memptr(threadnum), true);
+          if (status != 0) {
+            corr[pp] = -6;
+            valid = false;
+          }
+        }
+        if (!valid) continue;  // Skip updating evddata
+
+      }  // End of EVD
+
+      // If we have gotten this far, "eigvec" should contain the solution
+      // For MLE, its from smallestEigen and its largetstEigen for others
+      // Ensure first date of acquired SLCs is set to zero
+      {
+        std::complex<double> cJ(0.0, 1.0);
+        double ph0 = std::arg(workers[threadnum].eigvec[miniStackCount - 1]);
+        for (int ii = 0; ii < nbands; ii++) {
+          double res = std::arg(workers[threadnum].eigvec[ii]);
+          evddata.at(pp, ii) = std::exp(cJ * (res - ph0));
+        }
+
+        // Ensure that the reference index is exactly 1 - i.e, phase 0
+        evddata.at(pp, miniStackCount - 1) = std::complex<float>(1.0, 0.0);
+      }
+
+      // compress acquired SLCs of the stack.
+      // This is common to all methods
+      // For sequential approach previous compressed SLCs are excluded in the
+      // current compression
+      {
+        std::complex<double> sumcomp = 0.0;
+        for (int ii = miniStackCount - 1; ii < nbands; ii++) {
+          sumcomp += cpxdata.at(pp, ii) * std::conj(evddata.at(pp, ii));
+        }
+        comp.at(pp) = sumcomp / (1.0 * (nbands - miniStackCount + 1));
+      }
+
+      // Temporal coherence estimation
+      // This is common to all methods
+      {
+        std::complex<double> tempcorr(0.0, 0.0);
+        std::complex<double> cJ(0.0, 1.0);
+        int counter = 0;
+        for (int ti = 0; ti < nbands; ti++) {
+          int ulim = isstbas ? (ti + BW + 1) : nbands;
+          for (int tj = ti + 1; tj < ulim; tj++) {
+            int ind = ti + nbands * tj;
+
+            tempcorr += std::exp(cJ * (std::arg(Covar.at(ti, tj, threadnum)) -
+                                       std::arg(evddata.at(pp, ti)) +
+                                       std::arg(evddata.at(pp, tj))));
+            counter++;
+          }
+        }
+        corr.at(pp) = std::abs(tempcorr) / (counter * 1.0);
+      }
+    }
+
+    // Write the data to output bands
+    for (int ii = 0; ii < nbands; ii++) {
+      int status = outDataset[ii]->GetRasterBand(1)->RasterIO(
+          GF_Write, 0, yoff + firstlinetowrite, cols, linestowrite,
+          (void *)(evddata.colptr(ii) + firstlinetowrite * cols), cols,
+          linestowrite, GDT_CFloat32, sizeof(std::complex<float>),
+          sizeof(std::complex<float>) * cols, NULL);
+
+      if (status != 0) {
+        std::cout << "Error writing EVD data at line " << yoff << " for band "
+                  << ii + 1 << "\n";
+        std::cout << "Exiting with error code .... (120) \n";
+        GDALClose(inDataset);
+        GDALClose(wtsDataset);
+        GDALClose(corrDataset);
+        GDALClose(compDataset);
+        for (int jj = 0; jj < nbands; jj++) GDALClose(outDataset[jj]);
+        GDALDestroyDriverManager();
+        return 120;
+      }
+    }
+
+    // Write the temporal correlation data
+    {
+      int status = corrDataset->GetRasterBand(1)->RasterIO(
+          GF_Write, 0, yoff + firstlinetowrite, cols, linestowrite,
+          (void *)(corr.memptr() + firstlinetowrite * cols), cols, linestowrite,
+          GDT_Float32, sizeof(float), sizeof(float) * cols, NULL);
+
+      if (status != 0) {
+        std::cout << "Error writing temporal correlation data at line " << yoff
+                  << "\n";
+        std::cout << "Exiting with error code .... (121) \n";
+        GDALClose(inDataset);
+        GDALClose(wtsDataset);
+        GDALClose(corrDataset);
+        GDALClose(compDataset);
+        for (int jj = 0; jj < nbands; jj++) GDALClose(outDataset[jj]);
+        GDALDestroyDriverManager();
+        return 121;
+      }
+    }
+
+    // Write the compressed SLC data
+    {
+      int status = compDataset->GetRasterBand(1)->RasterIO(
+          GF_Write, 0, yoff + firstlinetowrite, cols, linestowrite,
+          (void *)(comp.memptr() + firstlinetowrite * cols), cols, linestowrite,
+          GDT_CFloat32, sizeof(std::complex<float>),
+          sizeof(std::complex<float>) * cols, NULL);
+
+      if (status != 0) {
+        std::cout << "Error writing temporal correlation data at line " << yoff
+                  << "\n";
+        std::cout << "Exiting with error code .... (121) \n";
+        GDALClose(inDataset);
+        GDALClose(wtsDataset);
+        GDALClose(corrDataset);
+        GDALClose(compDataset);
+        for (int jj = 0; jj < nbands; jj++) GDALClose(outDataset[jj]);
+        GDALDestroyDriverManager();
+        return 121;
+      }
+    }
+
+    // Update the counter
+    if ((yoff + blockysize) < rows) {
+      yoff += linestowrite - rollback;
+    } else {
+      yoff = rows;
+    }
+
+    GDALTermProgress(yoff / (1.0 * rows), NULL, NULL);
+  }
+
+  // Free the workers
+  delete[] workers;
+
+  // Close the datasets
+  GDALClose(inDataset);
+  GDALClose(wtsDataset);
+  for (int b = 0; b < nbands; b++) {
+    GDALClose(outDataset[b]);
+  }
+  GDALClose(corrDataset);
+  GDALClose(compDataset);
+  return (0);
 };
 
-
-
 /* Main driver*/
-int main(int  argc, const char *argv[] ) {
+int main(int argc, const char *argv[]) {
+  // Options
+  evdOptions opts;
+  int status;
 
-    //Options  
-    evdOptions opts;
-    int status;
+  // Parse command line options
+  status = opts.initFromCmdLine(argc, argv);
 
-    //Parse command line options
-    status = opts.initFromCmdLine(argc, argv);
+  if (status != 0) {
+    std::cout << "Error parsing command line inputs \n";
+    std::cout << "Exiting with non-zero return code .... \n";
+    return (101);
+  }
 
-    if (status != 0)
-    {
-        std::cout << "Error parsing command line inputs \n";
-        std::cout << "Exiting with non-zero return code .... \n";
-        return (101);
-    }
+  // Execute
+  status = evd_process(&opts);
 
+  if (status != 0) {
+    std::cout << "Error processing calamp \n";
+    std::cout << "Exiting with non-zero return code ....\n";
+    return (status);
+  }
 
-    //Execute 
-    status = evd_process(&opts);
-
-    if (status != 0)
-    {
-        std::cout << "Error processing calamp \n";
-        std::cout << "Exiting with non-zero return code ....\n";
-        return (status);
-    }
-
-    return(0);
-       
+  return (0);
 };

--- a/src/phase_link/phase_link.hpp
+++ b/src/phase_link/phase_link.hpp
@@ -5,182 +5,183 @@
  * \author Piyush Agram.
  *  */
 
-#include <iostream> 
-#include <string>
-#include <vector>  
 #include <cmath>
+#include <complex>
 #include <cstdio>
 #include <cstdlib>
-#include <complex>  
+#include <iostream>
+#include <string>
+#include <vector>
+
 #include "fringe/args.hxx"
 #include "fringe/ulongmask.hpp"
 
-//Input options for evd
-struct evdOptions
-{
-    //Inputs
-    std::string inputDS;     //Input VRT with SLCs as bands
-    std::string wtsDS;       //Self similar neighbot bit mask
+// Input options for evd
+struct evdOptions {
+  // Inputs
+  std::string inputDS;  // Input VRT with SLCs as bands
+  std::string wtsDS;    // Self similar neighbot bit mask
 
-    //Outputs
-    std::string compSlc;     // name of compressed SLC
-    std::string outputCompressedSlcFolder;  //output folder to store compressed SLCs
-    std::string outputFolder;       //output stack
-    std::string coherence;          //Coherence of the EVD description
-    std::string compSLC;            //Compressed SLC
+  // Outputs
+  std::string compSlc;  // name of compressed SLC
+  std::string
+      outputCompressedSlcFolder;  // output folder to store compressed SLCs
+  std::string outputFolder;       // output stack
+  std::string coherence;          // Coherence of the EVD description
+  std::string compSLC;            // Compressed SLC
 
-    //Memory and blocking options
-    int blocksize;           //Block size in rows
-    int memsize;             //Memory in MB that can be used by the program
+  // Memory and blocking options
+  int blocksize;  // Block size in rows
+  int memsize;    // Memory in MB that can be used by the program
 
-    //Neighborhood options
-    int Nx;   //Half window size in pixels
-    int Ny;   //Hald window size in lines
-    int minNeighbors; //Minimum number of neighbors
+  // Neighborhood options
+  int Nx;            // Half window size in pixels
+  int Ny;            // Hald window size in lines
+  int minNeighbors;  // Minimum number of neighbors
 
-    //Choice of method - MLE / EVD/ STBAS
-    std::string method;
+  // Choice of method - MLE / EVD/ STBAS
+  std::string method;
 
-    //Sequential options
-    int miniStackCount; //A counter for miniStack, used when Sequential algorithm is used. For one single stack of all acquisitions, miniStackCount = 1
+  // Sequential options
+  int miniStackCount;  // A counter for miniStack, used when Sequential
+                       // algorithm is used. For one single stack of all
+                       // acquisitions, miniStackCount = 1
 
-    //STBAS options
-    int bandWidth; //Bandwidth for STBAS
-    
-    //Functions
-    evdOptions();        //Default constructor 
-    int initFromCmdLine(int, const char**); //Command line parser
-    void print();   //Print Report
+  // STBAS options
+  int bandWidth;  // Bandwidth for STBAS
+
+  // Functions
+  evdOptions();                             // Default constructor
+  int initFromCmdLine(int, const char **);  // Command line parser
+  void print();                             // Print Report
 };
 
-
-//Default constructor
-evdOptions::evdOptions()
-{
-    blocksize = 64;
-    memsize = 2048;
-    Nx = 5;
-    Ny = 5;
-    minNeighbors = 2;
-    miniStackCount = 1;
-    method = "MLE";
-    bandWidth = -1;
+// Default constructor
+evdOptions::evdOptions() {
+  blocksize = 64;
+  memsize = 2048;
+  Nx = 5;
+  Ny = 5;
+  minNeighbors = 2;
+  miniStackCount = 1;
+  method = "MLE";
+  bandWidth = -1;
 }
 
+// Command line parser
+int evdOptions::initFromCmdLine(int argc, const char **argv) {
+  args::ArgumentParser parser("Eigen value decomposition of a stack of SLCs");
+  args::HelpFlag flag(parser, "help", "Display this help menu", {'h', "help"});
+  args::ValueFlag<std::string> input(parser, "inputDS*", "Input Stack VRT",
+                                     {'i'});
+  args::ValueFlag<std::string> mask(parser, "wtsDS*", "Input neighbor mask",
+                                    {'w'});
+  args::ValueFlag<std::string> outfolder(parser, "output*",
+                                         "Output folder for new stack", {'o'});
+  args::ValueFlag<std::string> compfolder(
+      parser, "outputComp*", "Output folder for compressed SLC", {'c'});
+  args::ValueFlag<std::string> compname(parser, "compSlcName*",
+                                        "Output compressed SLC", {'s'});
+  args::ValueFlag<int> lpb(parser, "linesperblock",
+                           "Lines per block for processing", {'l'});
+  args::ValueFlag<int> mems(parser, "memorysize", "Memory in Mb", {'r'});
+  args::ValueFlag<int> xx(parser, "xsize", "Half window in x", {'x'});
+  args::ValueFlag<int> yy(parser, "ysize", "Half window in y", {'y'});
+  args::ValueFlag<int> mm(parser, "minNeighbors", "Minimum number of neighbors",
+                          {'n'});
+  args::ValueFlag<int> kk(parser, "miniStackCount", "Mini-stack count", {'k'});
+  args::ValueFlag<std::string> tmethod(
+      parser, "method", "Decomposition method - MLE / EVD/ STBAS", {'m'});
+  args::ValueFlag<int> bw(parser, "bandWidth", "STBAS bandwidth", {'b'});
+  try {
+    parser.ParseCLI(argc, argv);
+  } catch (args::Help) {
+    std::cout << parser;
+    return 1;
+  } catch (args::ParseError e) {
+    std::cerr << e.what() << std::endl;
+    std::cerr << parser;
+    return 1;
+  } catch (args::ValidationError e) {
+    std::cerr << e.what() << std::endl;
+    std::cerr << parser;
+    return 1;
+  }
 
-//Command line parser
-int evdOptions::initFromCmdLine(int argc, const char **argv)
-{
+  if ((!input) || (!mask) || (!outfolder)) {
+    std::cerr << parser;
+    return 1;
+  }
 
-    args::ArgumentParser parser("Eigen value decomposition of a stack of SLCs");
-    args::HelpFlag flag(parser, "help", "Display this help menu", {'h', "help"});
-    args::ValueFlag<std::string> input(parser, "inputDS*", "Input Stack VRT", {'i'});
-    args::ValueFlag<std::string> mask(parser, "wtsDS*", "Input neighbor mask", {'w'});
-    args::ValueFlag<std::string> outfolder(parser, "output*", "Output folder for new stack", {'o'});
-    args::ValueFlag<std::string> compfolder(parser, "outputComp*", "Output folder for compressed SLC", {'c'});
-    args::ValueFlag<std::string> compname(parser, "compSlcName*", "Output compressed SLC", {'s'});
-    args::ValueFlag<int> lpb(parser,"linesperblock", "Lines per block for processing", {'l'});
-    args::ValueFlag<int> mems(parser,"memorysize", "Memory in Mb", {'r'});
-    args::ValueFlag<int> xx(parser, "xsize", "Half window in x", {'x'});
-    args::ValueFlag<int> yy(parser, "ysize", "Half window in y", {'y'});
-    args::ValueFlag<int> mm(parser, "minNeighbors", "Minimum number of neighbors", {'n'});
-    args::ValueFlag<int> kk(parser, "miniStackCount", "Mini-stack count", {'k'});
-    args::ValueFlag<std::string> tmethod(parser, "method", "Decomposition method - MLE / EVD/ STBAS", {'m'});
-    args::ValueFlag<int> bw(parser, "bandWidth", "STBAS bandwidth", {'b'});
-    try
-    {
-        parser.ParseCLI(argc, argv);
+  inputDS = args::get(input);
+  wtsDS = args::get(mask);
+  outputFolder = args::get(outfolder);
+  if (xx) {
+    Nx = args::get(xx);
+  }
+  if (yy) {
+    Ny = args::get(yy);
+  }
+  if (lpb) {
+    blocksize = args::get(lpb);
+  }
+  if (mems) {
+    memsize = args::get(mems);
+  }
+  if (mm) {
+    minNeighbors = args::get(mm);
+  }
+  if (kk) {
+    miniStackCount = args::get(kk);
+  }
+  if (bw) {
+    bandWidth = args::get(bw);
+  }
+  if (compfolder) {
+    outputCompressedSlcFolder = args::get(compfolder);
+    if (compname) {
+      compSLC = args::get(compname);
+    } else {
+      compSLC = "compslc.bin";
     }
-    catch (args::Help)
-    {
-        std::cout << parser;
-        return 1;
-    }
-    catch (args::ParseError e)
-    {
-        std::cerr << e.what() << std::endl;
-        std::cerr << parser;
-        return 1;
-    }
-    catch(args::ValidationError e)
-    {
-        std::cerr << e.what() << std::endl;
-        std::cerr << parser;
-        return 1;
-    }
+  } else {
+    outputCompressedSlcFolder = args::get(outfolder);
+    compSLC = "compslc.bin";
+  }
 
-
-    if ( (!input) || (!mask) || (!outfolder))
-    {
-        std::cerr << parser;
-        return 1;
+  if (tmethod) {
+    std::string inmethod = args::get(tmethod);
+    if ((inmethod.compare("MLE") == 0) || (inmethod.compare("EVD") == 0) ||
+        (inmethod.compare("STBAS") == 0)) {
+      method = inmethod;
+    } else {
+      std::cout << "Input method must be MLE or EVD or STBAS \n";
+      std::cerr << parser;
+      return 1;
     }
+  }
 
-    inputDS = args::get(input);
-    wtsDS = args::get(mask);
-    outputFolder = args::get(outfolder);
-    if (xx) { Nx = args::get(xx);}
-    if (yy) {Ny = args::get(yy);}
-    if (lpb) {blocksize = args::get(lpb);}
-    if (mems) {memsize = args::get(mems);}
-    if (mm) {minNeighbors = args::get(mm);}
-    if (kk) {miniStackCount = args::get(kk);}
-    if (bw) {bandWidth = args::get(bw);}
-    if (compfolder) {
-       outputCompressedSlcFolder = args::get(compfolder);
-       if (compname) {
-           compSLC = args::get(compname);
-       }
-       else{
-           compSLC = "compslc.bin";
-       }
-    }
-    else{
-       outputCompressedSlcFolder = args::get(outfolder);
-       compSLC = "compslc.bin";
-    }
-
-    if (tmethod)
-    {
-        std::string inmethod = args::get(tmethod);
-        if ( (inmethod.compare("MLE")==0) || (inmethod.compare("EVD")==0) || (inmethod.compare("STBAS")==0))
-        {
-            method = inmethod;
-        }
-        else
-        {
-            std::cout << "Input method must be MLE or EVD or STBAS \n";
-            std::cerr << parser;
-            return 1;
-        }
-    }
-
-
-
-    return 0;
+  return 0;
 }
 
+// Print report
+void evdOptions::print() {
+  std::cout << "Input Dataset: " << inputDS << std::endl;
+  std::cout << "Weights Dataset: " << wtsDS << std::endl;
 
-//Print report
-void evdOptions::print()
-{
+  std::cout << "Output Folder " << outputFolder << std::endl;
+  std::cout << "Output compressed SLC folder " << outputCompressedSlcFolder
+            << std::endl;
+  std::cout << "Output compressed SLC " << compSlc << std::endl;
+  std::cout << "Window size: " << Nx << " " << Ny << std::endl;
+  std::cout << "Memsize: " << memsize << " Mb \n";
+  std::cout << "Blocksize: " << blocksize << " lines \n";
+  std::cout << "Minimum neighbors: " << minNeighbors << "\n";
+  std::cout << "Mini-stack counter: " << miniStackCount << "\n";
 
-    std::cout << "Input Dataset: " << inputDS << std::endl;
-    std::cout << "Weights Dataset: " << wtsDS << std::endl;
-    
-    std::cout << "Output Folder " << outputFolder << std::endl;
-    std::cout << "Output compressed SLC folder " << outputCompressedSlcFolder << std::endl;
-    std::cout << "Output compressed SLC " << compSlc << std::endl;
-    std::cout << "Window size: " << Nx << " " << Ny << std::endl;
-    std::cout << "Memsize: " << memsize << " Mb \n";
-    std::cout << "Blocksize: " << blocksize << " lines \n";
-    std::cout << "Minimum neighbors: " << minNeighbors << "\n";
-    std::cout << "Mini-stack counter: " << miniStackCount << "\n";
-
-    std::cout << "Decomposition method: " << method <<"\n";
-    if (method.compare("STBAS") == 0)
-    {
-        std::cout << "STBAS Bandwidth: " << bandWidth << "\n";
-    }
-}   
-#endif //FRINGE_EVD_H
+  std::cout << "Decomposition method: " << method << "\n";
+  if (method.compare("STBAS") == 0) {
+    std::cout << "STBAS Bandwidth: " << bandWidth << "\n";
+  }
+}
+#endif  // FRINGE_EVD_H

--- a/src/phase_link/phase_link.hpp
+++ b/src/phase_link/phase_link.hpp
@@ -1,0 +1,186 @@
+#ifndef FRINGE_EVD_H
+#define FRINGE_EVD_H
+
+/***
+ * \author Piyush Agram.
+ *  */
+
+#include <iostream> 
+#include <string>
+#include <vector>  
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <complex>  
+#include "fringe/args.hxx"
+#include "fringe/ulongmask.hpp"
+
+//Input options for evd
+struct evdOptions
+{
+    //Inputs
+    std::string inputDS;     //Input VRT with SLCs as bands
+    std::string wtsDS;       //Self similar neighbot bit mask
+
+    //Outputs
+    std::string compSlc;     // name of compressed SLC
+    std::string outputCompressedSlcFolder;  //output folder to store compressed SLCs
+    std::string outputFolder;       //output stack
+    std::string coherence;          //Coherence of the EVD description
+    std::string compSLC;            //Compressed SLC
+
+    //Memory and blocking options
+    int blocksize;           //Block size in rows
+    int memsize;             //Memory in MB that can be used by the program
+
+    //Neighborhood options
+    int Nx;   //Half window size in pixels
+    int Ny;   //Hald window size in lines
+    int minNeighbors; //Minimum number of neighbors
+
+    //Choice of method - MLE / EVD/ STBAS
+    std::string method;
+
+    //Sequential options
+    int miniStackCount; //A counter for miniStack, used when Sequential algorithm is used. For one single stack of all acquisitions, miniStackCount = 1
+
+    //STBAS options
+    int bandWidth; //Bandwidth for STBAS
+    
+    //Functions
+    evdOptions();        //Default constructor 
+    int initFromCmdLine(int, const char**); //Command line parser
+    void print();   //Print Report
+};
+
+
+//Default constructor
+evdOptions::evdOptions()
+{
+    blocksize = 64;
+    memsize = 2048;
+    Nx = 5;
+    Ny = 5;
+    minNeighbors = 2;
+    miniStackCount = 1;
+    method = "MLE";
+    bandWidth = -1;
+}
+
+
+//Command line parser
+int evdOptions::initFromCmdLine(int argc, const char **argv)
+{
+
+    args::ArgumentParser parser("Eigen value decomposition of a stack of SLCs");
+    args::HelpFlag flag(parser, "help", "Display this help menu", {'h', "help"});
+    args::ValueFlag<std::string> input(parser, "inputDS*", "Input Stack VRT", {'i'});
+    args::ValueFlag<std::string> mask(parser, "wtsDS*", "Input neighbor mask", {'w'});
+    args::ValueFlag<std::string> outfolder(parser, "output*", "Output folder for new stack", {'o'});
+    args::ValueFlag<std::string> compfolder(parser, "outputComp*", "Output folder for compressed SLC", {'c'});
+    args::ValueFlag<std::string> compname(parser, "compSlcName*", "Output compressed SLC", {'s'});
+    args::ValueFlag<int> lpb(parser,"linesperblock", "Lines per block for processing", {'l'});
+    args::ValueFlag<int> mems(parser,"memorysize", "Memory in Mb", {'r'});
+    args::ValueFlag<int> xx(parser, "xsize", "Half window in x", {'x'});
+    args::ValueFlag<int> yy(parser, "ysize", "Half window in y", {'y'});
+    args::ValueFlag<int> mm(parser, "minNeighbors", "Minimum number of neighbors", {'n'});
+    args::ValueFlag<int> kk(parser, "miniStackCount", "Mini-stack count", {'k'});
+    args::ValueFlag<std::string> tmethod(parser, "method", "Decomposition method - MLE / EVD/ STBAS", {'m'});
+    args::ValueFlag<int> bw(parser, "bandWidth", "STBAS bandwidth", {'b'});
+    try
+    {
+        parser.ParseCLI(argc, argv);
+    }
+    catch (args::Help)
+    {
+        std::cout << parser;
+        return 1;
+    }
+    catch (args::ParseError e)
+    {
+        std::cerr << e.what() << std::endl;
+        std::cerr << parser;
+        return 1;
+    }
+    catch(args::ValidationError e)
+    {
+        std::cerr << e.what() << std::endl;
+        std::cerr << parser;
+        return 1;
+    }
+
+
+    if ( (!input) || (!mask) || (!outfolder))
+    {
+        std::cerr << parser;
+        return 1;
+    }
+
+    inputDS = args::get(input);
+    wtsDS = args::get(mask);
+    outputFolder = args::get(outfolder);
+    if (xx) { Nx = args::get(xx);}
+    if (yy) {Ny = args::get(yy);}
+    if (lpb) {blocksize = args::get(lpb);}
+    if (mems) {memsize = args::get(mems);}
+    if (mm) {minNeighbors = args::get(mm);}
+    if (kk) {miniStackCount = args::get(kk);}
+    if (bw) {bandWidth = args::get(bw);}
+    if (compfolder) {
+       outputCompressedSlcFolder = args::get(compfolder);
+       if (compname) {
+           compSLC = args::get(compname);
+       }
+       else{
+           compSLC = "compslc.bin";
+       }
+    }
+    else{
+       outputCompressedSlcFolder = args::get(outfolder);
+       compSLC = "compslc.bin";
+    }
+
+    if (tmethod)
+    {
+        std::string inmethod = args::get(tmethod);
+        if ( (inmethod.compare("MLE")==0) || (inmethod.compare("EVD")==0) || (inmethod.compare("STBAS")==0))
+        {
+            method = inmethod;
+        }
+        else
+        {
+            std::cout << "Input method must be MLE or EVD or STBAS \n";
+            std::cerr << parser;
+            return 1;
+        }
+    }
+
+
+
+    return 0;
+}
+
+
+//Print report
+void evdOptions::print()
+{
+
+    std::cout << "Input Dataset: " << inputDS << std::endl;
+    std::cout << "Weights Dataset: " << wtsDS << std::endl;
+    
+    std::cout << "Output Folder " << outputFolder << std::endl;
+    std::cout << "Output compressed SLC folder " << outputCompressedSlcFolder << std::endl;
+    std::cout << "Output compressed SLC " << compSlc << std::endl;
+    std::cout << "Window size: " << Nx << " " << Ny << std::endl;
+    std::cout << "Memsize: " << memsize << " Mb \n";
+    std::cout << "Blocksize: " << blocksize << " lines \n";
+    std::cout << "Minimum neighbors: " << minNeighbors << "\n";
+    std::cout << "Mini-stack counter: " << miniStackCount << "\n";
+
+    std::cout << "Decomposition method: " << method <<"\n";
+    if (method.compare("STBAS") == 0)
+    {
+        std::cout << "STBAS Bandwidth: " << bandWidth << "\n";
+    }
+}   
+#endif //FRINGE_EVD_H

--- a/src/phase_link/phase_link.py
+++ b/src/phase_link/phase_link.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+
+import os
+import argparse
+
+def cmdLineParser():
+    '''
+    Command line parser.
+    '''
+
+    parser = argparse.ArgumentParser(description = 'Perform MLE-based phase-linking on a stack of coregistered SLCs',
+                formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument('-i', '--input', type=str, dest='inputDS',
+            required=True, help='Input GDAL SLC stack VRT')
+    parser.add_argument('-w', '--wts', type=str, dest='wtsDS',
+            required=True, help='Input weights dataset')
+    parser.add_argument('-o', '--output', type=str, dest='outputFolder',
+            required=True, help='Output folder with phase-linked SLCs')
+    parser.add_argument('-l', '--linesperblock', type=int, dest='linesPerBlock',
+            default=64, help='Quantum for block of lines')
+    parser.add_argument('-r', '--ram', type=int, dest='memorySize',
+            default=2048, help='Memory in Mb to use')
+    parser.add_argument('-x', '--xhalf', type=int, dest='halfWindowX',
+            default=5, help='Half window size (range)')
+    parser.add_argument('-y', '--yhalf', type=int, dest='halfWindowY',
+            default=5, help='Half window size (azimuth)')
+    parser.add_argument('-n', '--minneigh', type=int, dest='minNeighbors',
+            default=5, help='Minimum number of neighbors for computation')
+    parser.add_argument('-m', '--method', type=str, dest='method',
+            default='MLE', help='Decomposition method to use - MLE / EVD / STBAS')
+    parser.add_argument('-b', '--bandwidth', type=int, dest='bandWidth',
+            default=-1, help='Diagonal bandwidth for STBAS')
+
+    return parser.parse_args()
+
+
+def runEvd(inps):
+    '''
+    Actually run Evd.
+    '''
+
+    import os
+    os.environ['OPENBLAS_NUM_THREADS'] = "1"
+
+    import phase_linklib
+    aa = phase_linklib.Phaselink()
+    
+    ###Explicit wiring. Can be automated later.
+    aa.inputDS = inps.inputDS
+    aa.weightsDS = inps.wtsDS
+    aa.outputFolder = inps.outputFolder
+
+    aa.outputCompressedSlcFolder = aa.outputFolder
+    aa.compSlc = "compslc.bin"
+
+    aa.blocksize = inps.linesPerBlock
+    aa.memsize = inps.memorySize
+    aa.halfWindowX = inps.halfWindowX
+    aa.halfWindowY = inps.halfWindowY
+    aa.minimumNeighbors = inps.minNeighbors
+    
+    ##Set up method and bandwidth
+    aa.method = inps.method
+    aa.bandWidth = inps.bandWidth
+
+    aa.run()
+
+
+if __name__ == '__main__':
+    '''
+    Main driver.
+    '''
+
+    inps = cmdLineParser()
+
+    runEvd(inps)
+

--- a/src/phase_link/phase_linklib.pyx
+++ b/src/phase_link/phase_linklib.pyx
@@ -1,0 +1,157 @@
+from libcpp.string cimport string
+
+cdef extern from "phase_link.hpp":
+    cdef cppclass evdOptions:
+        evdOptions() except +
+        void print()
+
+        string inputDS
+        string wtsDS
+        string outputFolder
+        string outputCompressedSlcFolder
+        string compSlc
+        string coherence
+
+        int blocksize
+        int memsize
+
+        double prob
+
+        int Nx
+        int Ny
+        int minNeighbors
+
+        string method 
+
+        int miniStackCount
+        int bandWidth
+
+cdef extern from "phase_link.cpp":
+    int evd_process(evdOptions*) nogil
+
+
+cdef class Phaselink:
+    '''
+    Python wrapper for evd.
+    '''
+
+    cdef evdOptions *thisptr
+
+    def __cinit__(self):
+        self.thisptr = new evdOptions()
+
+
+    def __dealloc__(self):
+        del self.thisptr
+
+    @property
+    def inputDS(self):
+        return self.thisptr.inputDS.decode('utf-8')
+
+    @inputDS.setter
+    def inputDS(self,x):
+        self.thisptr.inputDS = x.encode('utf-8')
+
+
+    @property
+    def outputFolder(self):
+        return self.thisptr.outputFolder.decode('utf-8')
+
+    @outputFolder.setter
+    def outputFolder(self,x):
+        self.thisptr.outputFolder = x.encode('utf-8')
+
+    @property
+    def outputCompressedSlcFolder(self):
+        return self.thisptr.outputCompressedSlcFolder.decode('utf-8')
+
+    @outputCompressedSlcFolder.setter
+    def outputCompressedSlcFolder(self,x):
+        self.thisptr.outputCompressedSlcFolder = x.encode('utf-8')
+    
+    @property
+    def compSlc(self):
+        return self.thisptr.compSlc.decode('utf-8')
+
+    @compSlc.setter
+    def compSlc(self,x):
+        self.thisptr.compSlc = x.encode('utf-8')
+
+    @property
+    def weightsDS(self):
+        return self.thisptr.wtsDS.decode('utf-8')
+
+    @weightsDS.setter
+    def weightsDS(self,x):
+        self.thisptr.wtsDS = x.encode('utf-8')
+
+    @property
+    def minimumNeighbors(self):
+        return self.thisptr.minNeighbors
+
+    @minimumNeighbors.setter
+    def minimumNeighbors(self,x):
+        self.thisptr.minNeighbors = x
+
+    @property
+    def miniStackCount(self):
+        return self.thisptr.miniStackCount
+
+    @miniStackCount.setter
+    def miniStackCount(self,x):
+        self.thisptr.miniStackCount = x
+
+    @property
+    def blocksize(self):
+        return self.thisptr.blocksize
+
+    @blocksize.setter
+    def blocksize(self,x):
+        self.thisptr.blocksize = x 
+
+    @property
+    def memsize(self):
+        return self.thisptr.memsize
+
+    @memsize.setter
+    def memsize(self,x):
+        self.thisptr.memsize = x
+
+    @property
+    def halfWindowX(self):
+        return self.thisptr.Nx
+
+    @halfWindowX.setter
+    def halfWindowX(self,x):
+        self.thisptr.Nx = x
+
+    @property
+    def halfWindowY(self):
+        return self.thisptr.Ny
+
+    @halfWindowY.setter
+    def halfWindowY(self,x):
+        self.thisptr.Ny = x
+
+    @property
+    def method(self):
+        return self.thisptr.method.decode('utf-8')
+
+    @method.setter
+    def method(self, x):
+        self.thisptr.method = x.encode('utf-8')
+
+    @property
+    def bandWidth(self):
+        return self.thisptr.bandWidth
+
+    @bandWidth.setter
+    def bandWidth(self,x):
+        self.thisptr.bandWidth = x
+
+    def print(self):
+        self.thisptr.print()
+
+    def run(self):
+        with nogil:
+            evd_process(self.thisptr)

--- a/tests/evd/test_evd.py
+++ b/tests/evd/test_evd.py
@@ -354,9 +354,14 @@ def main():
     cmd = f"evd.py -i {coreg_stack_dir}/slcs_base.vrt -w {nmap_output} -o {evd_output} -m EVD"
     os.system(cmd)
 
-    # run fringe evd module with MLE estimato
+    # run fringe evd module with MLE estimator
     mle_output = os.path.join(output_timeseries_dir, "mle")
     cmd = f"evd.py -i {coreg_stack_dir}/slcs_base.vrt -w {nmap_output} -o {mle_output} -m MLE"
+    os.system(cmd)
+
+    # run fringe phase_linking module
+    phase_link_output = os.path.join(output_timeseries_dir, "phase_link")
+    cmd = f"phase_link.py -i {coreg_stack_dir}/slcs_base.vrt -w {nmap_output} -o {phase_link_output} -m MLE"
     os.system(cmd)
 
     # read the estimated wrapped phase
@@ -366,6 +371,8 @@ def main():
     est_wrapped_phase_fringe_evd = read_wrapped_phase(evd_output, x0, y0)
 
     est_wrapped_phase_fringe_mle = read_wrapped_phase(mle_output, x0, y0)
+
+    est_wrapped_phase_fringe_phase_link = read_wrapped_phase(phase_link_output, x0, y0)
 
     # compare with simulated phase and calculate RMSE
     print(signal_phase.shape)
@@ -378,9 +385,16 @@ def main():
         np.exp(1j * signal_phase) * np.conjugate(est_wrapped_phase_fringe_mle)
     )
     rmse_fringe_mle = np.degrees(np.sqrt(np.sum(residual_mle**2, 0) / len(t)))
+
+    residual_phase_link = np.angle(
+        np.exp(1j * signal_phase) * np.conjugate(est_wrapped_phase_fringe_phase_link)
+    )
+    rmse_fringe_phase_link = np.degrees(np.sqrt(np.sum(residual_phase_link**2, 0) / len(t)))
+
     print("rmse for evd [degrees]:", np.degrees(rmse_evd))
     print("rmse for evd fringe [degrees]:", rmse_fringe_evd)
     print("rmse for mle fringe [degrees]:", rmse_fringe_mle)
+    print("rmse for phase-link fringe [degrees]:", rmse_fringe_phase_link)
 
 
     #######################
@@ -422,6 +436,7 @@ def main():
     # check the RMSE of the FRINGE results
     assert rmse_fringe_evd <= 10
     assert rmse_fringe_mle <= 10
+    assert rmse_fringe_phase_link <= 10
 
     # check the neighborhood map
     count = test_bit_mask(weight_dataset_name)


### PR DESCRIPTION
This PR adds a new workflow to estimate wrapped phase series. This module named "phase-link" tries to estimate the wrapped phase series for a given neighborhood based on EMI estimation. If the coherence matrix is positive definite and computing inverse is doable, the EMI estimation proceeds. If the coherence is not positive definite and computing its inverse is not doable, instead of giving up with any estimate, here we switch the gear to EVD (Eigenvalue and Vector Decomposition) of Covariance matrix. This significantly improves the estimation and gives wrapped phase estimates for many pixels which EMI alone may miss. In practice the positive definiteness check for the coherence matrix can fail even for cases with very high coherence. I experienced many examples where the coherence matrix is not positive definite and therefore the EMI estimation is not doable while falling back to evd leads to reliable phase estimate with very high temporal coherence of more than 0.9. 

Here is an example of a coherence matrix which EMI fails to give an estimate because the coherence is not positive definite. Obviously the coherence is very high and we should provide an estimate. 
<img width="640" alt="Screen Shot 2022-03-04 at 2 02 08 PM" src="https://user-images.githubusercontent.com/5033183/156898313-76fbec18-2b67-43ec-b12c-84f1a9c5b9b2.png">

The results of the new module (EMI + EVD) compared with the EMI estimation for one example dataset can be seen here where the first plot shows EMI only and the second plot shows EMI + EVD from phase-link module:
<img width="1149" alt="Screen Shot 2022-03-04 at 5 52 25 PM" src="https://user-images.githubusercontent.com/5033183/156898330-216aa73d-ecd1-4af3-8436-c2de64cce8b6.png">

<img width="1151" alt="Screen Shot 2022-03-04 at 5 52 15 PM" src="https://user-images.githubusercontent.com/5033183/156898333-05f4c3c0-acc1-45c8-9a51-acf81be4d9cc.png">

Note that the light blue pixels are all those pixels that no estimation is provided for by EMI. The example is for one ministack. This improvement is even more critical for workflows which would run on many mini-stacks. If randomly bunch of pixels are unnecessarily masked in each mini-stack estimation, the final results will have a lot more pixels excluded. 

In this PR I have not bothered to regularize the coherence matrix when it is not positive definite. Down the line we need to evaluate how efficient the regularization is and what is the gain compared to simply falling back to EVD when coherence is not positive definite. Nevertheless we know that regularization is not always doable and we will still need to fall back to EVD in many cases. 

Currently a lot of code is duplicated from evd. I had to make a choice with code duplication or modifying evd. I didn't want to make evd over complicated. Moreover I have relaxed the checks on the coherence and covariance matrices. The only checks that I have kept in phase-link are checking the positive-definiteness of the coherence matrix and check if Lapack can estimate the EVD of Covariance matrix. The rest of the checks seem un-necessary to me and were leading to skipping the estimation for many highly coherent neighborhoods. I think it is ok for short term to have the code duplication. Over long term it would be nice to have EMI and EVD core modules which can be called from phase-link.cpp or evd.cpp. Such changes coupled with handling rasters outside the modules will be a future clean up. Anyways for now I chose the code duplication for further testing the new workflow against the existing estimators in evd.cpp. 

  