### PR TITLE
Test evd nmap fix

### DIFF
--- a/tests/evd/test_evd.py
+++ b/tests/evd/test_evd.py
@@ -182,8 +182,6 @@ def test_bit_mask(filename):
 
     masker = BitMask(ny, nx)
 
-    wy, wx = (2 * ny + 1), (2 * nx + 1)
-    npix = wx * wy
     count = 0
     for ii in range(-ny, ny + 1):
         for jj in range(-nx, nx + 1):

--- a/tests/evd/test_evd.py
+++ b/tests/evd/test_evd.py
@@ -161,7 +161,7 @@ class BitMask:
         self.nx = nx
 
     def getbit(self, mask, ii, jj):
-        # Note: the nx is a half window size, and this is assuming 
+        # Note: the nx is a half window size, and this is assuming
         # jj goes from (-nx, nx) and ii goes from (-ny, ny)
         flat = (ii + self.ny) * (2 * self.nx + 1) + jj + self.nx
         num = flat // 8
@@ -179,7 +179,7 @@ def load_neighborhood(filename, row, col):
         Row of the pixel
     col: int
         column of pixel
-    
+
     Returns
     -------
     neighborhood : numpy array (dtype = np.bool)
@@ -227,8 +227,6 @@ def test_bit_mask(filename):
 
 
 def write_slc_stack(neighbor_stack, output_slc_dir, nx, ny, dt=12):
-    if os.path.exists(output_slc_dir):
-        shutil.rmtree(output_slc_dir)
     os.makedirs(output_slc_dir, exist_ok=False)
 
     nslc = neighbor_stack.shape[0]
@@ -249,8 +247,6 @@ def write_slc_stack(neighbor_stack, output_slc_dir, nx, ny, dt=12):
 
 
 def write_dummy_geometry(output_dir, nx, ny):
-    if os.path.exists(output_dir):
-        shutil.rmtree(output_dir)
     os.makedirs(output_dir, exist_ok=False)
     lat_name = os.path.join(output_dir, "lat.rdr.full")
     lon_name = os.path.join(output_dir, "lon.rdr.full")
@@ -348,6 +344,9 @@ def main():
 
     # output directory to store the simulated data for this unit test
     output_simulation_dir = "simulations"
+    if os.path.exists(output_simulation_dir):
+        shutil.rmtree(output_simulation_dir)
+
     # output subdirectory to store SLCs
     output_slc_dir = os.path.join(output_simulation_dir, "SLC")
     # write flat binary SLCs that Fringe can read

--- a/tests/evd/test_evd.py
+++ b/tests/evd/test_evd.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 
-from array import array
 import datetime
 import glob
 import os
 import re
+from array import array
+
 import numpy as np
 from osgeo import gdal
+
 
 def simulate_noise(corr_matrix: np.array) -> np.array:
     N = corr_matrix.shape[0]
@@ -48,12 +50,12 @@ def simulate_coherence_matrix(t, gamma0, gamma_inf, Tau0, ph):
 
 
 def simulate_phase_timeSeries(
-        time_series_length: int = 365, acquisition_interval: int = 12, signal_rate: float = 1.0, std_random: float = 0, k: int = 1
-        ):
+    time_series_length: int = 365, acquisition_interval: int = 12, signal_rate: float = 1.0, std_random: float = 0, k: int = 1
+):
     # time_series_length: length of time-series in days
-    # acquisition_interval: time-differense between subsequent acquisitions (days)
+    # acquisition_interval: time-difference between subsequent acquisitions (days)
     # signal_rate: linear rate of the signal (rad/year)
-    # k: seasonal parameter, 1 for annaual and  2 for semi-annual
+    # k: seasonal parameter, 1 for annual and  2 for semi-annual
     t = np.arange(0, time_series_length, acquisition_interval)
     signal_phase = signal_rate * (t - t[0]) / 365.0
     if k > 0:
@@ -92,15 +94,14 @@ def compute_covariance_matrix(neighbor_stack):
 
 
 def estimate_evd(cov_mat):
-
-    # estimate the wrapped phase based on the eigen value decomposition of the covariance matrix
+    # estimate the wrapped phase based on the eigenvalue decomposition of the covariance matrix
     w, v = np.linalg.eigh(cov_mat)
 
-    # the last eignevalue is the maximum eigenvalue
+    # the last eigenvalue is the maximum eigenvalue
     # However let's check to make sure
     ind_max = np.argmax(w)
 
-    # the eignevector corresponding to the largest eigenvalue
+    # the eigenvector corresponding to the largest eigenvalue
     # of the covariance matrix is the solution
     evd_estimate = v[:, ind_max]
 
@@ -295,7 +296,7 @@ def main():
         k=2,
     )
 
-    # paraneters of a coherence model
+    # parameters of a coherence model
     gamma0 = 0.999
     gamma_inf = 0.99
     Tau0 = 72
@@ -306,7 +307,7 @@ def main():
     # number of samples in the neighborhood
     neighbor_samples = ny * nx
 
-    # simulate a complex covraince matrix based on the
+    # simulate a complex covariance matrix based on the
     # simulated phase and coherence model
     simulated_covariance_matrix = simulate_coherence_matrix(
         t, gamma0, gamma_inf, Tau0, signal_phase

--- a/tests/evd/test_evd.py
+++ b/tests/evd/test_evd.py
@@ -114,21 +114,11 @@ def simulate_bit_mask(ny, nx, filename="neighborhood_map"):
 
     # number of uint32 bytes needed to store weights
     number_of_bytes = np.ceil((ny * nx) / 32)
-
-    flags = np.ones((ny, nx), dtype=np.bool_)
-    flag_bits = np.zeros((ny, nx), dtype=np.uint8)
-
-    for ii in range(ny):
-        for jj in range(nx):
-            flag_bits[ii, jj] = flags[ii, jj].astype(np.uint8)
-
-    # create the weight dataset for 1 neighborhood
-    cols = nx
-    rows = ny
+    # create the weight dataset for 1 neighborhood (a single pixel)
     n_bands = int(number_of_bytes)
     drv = gdal.GetDriverByName("ENVI")
     options = ["INTERLEAVE=BIP"]
-    ds = drv.Create(filename, cols, rows, n_bands, gdal.GDT_UInt32, options)
+    ds = drv.Create(filename, 1, 1, n_bands, gdal.GDT_UInt32, options)
 
     half_window_y = int(ny / 2)
     half_window_x = int(nx / 2)
@@ -142,11 +132,11 @@ def simulate_bit_mask(ny, nx, filename="neighborhood_map"):
 
     # Let's assume in the neighborhood of nx*ny all pixels are
     # similar to the center pixel
-    s = "1" * (nx * ny * n_bands * 4 * 8)
+    s = "1" * nx * ny
+
+    bits = s.ljust(n_bands * 4 * 8, "0")  # pad it to length n_bands*32
 
     bin_array = array("B")
-    bits = s.ljust(n_bands * nx * ny * 4 * 8, "0")  # pad it to length n_bands*32
-
     for octect in re.findall(r"\d{8}", bits):  # split it in 4 octects
         bin_array.append(int(octect[::-1], 2))  # reverse them and append it
 

--- a/tests/evd/test_evd.py
+++ b/tests/evd/test_evd.py
@@ -184,16 +184,10 @@ def test_bit_mask(filename):
 
     wy, wx = (2 * ny + 1), (2 * nx + 1)
     npix = wx * wy
-    bitmask = np.zeros(npix, dtype=bool)
     count = 0
-    ind = 0
     for ii in range(-ny, ny + 1):
         for jj in range(-nx, nx + 1):
-            flag = masker.getbit(mask, ii, jj)
-            bitmask[ind] = flag == 1
-            if flag:
-                count += 1
-            ind += 1
+            count += masker.getbit(mask, ii, jj)
 
     return count
 


### PR DESCRIPTION
Changed the neighborhood map test to match the c++ functionality. Also changed the test so that 1 pixel out of the window is 0 (not a neighbor).

Another quick way to do this in numpy is using the `packbits` function:
```python
In [122]: a = np.ones((7, 5), dtype=bool)

In [123]: a[0, 0] = False

In [124]: np.packbits(a, bitorder="little")
Out[124]: array([254, 255, 255, 255,   7], dtype=uint8)
```

This matches what's now created it in `simulate_bit_mask` function.
```bash
(mapping) [staniewi@aurora fringe]$ hexdump neighborhood_map
0000000 fffe ffff 0007 0000
0000008
```