### PR TITLE
ampdispersion: add the number of SLCs to metadata

### DIFF
--- a/src/ampdispersion/ampdispersion.cpp
+++ b/src/ampdispersion/ampdispersion.cpp
@@ -283,6 +283,10 @@ int ampdispersion_process(ampdispersionOptions *opts)
 
     std::cout << "ampdispersion processing time: " << (t_end-t_start)/60.0 << " mins \n";
 
+    //Annotate the output datasets with number of SLCs/nbands used for future reference
+    status = daDataset->SetMetadataItem("N", std::to_string(nbands).c_str(), NULL);
+    status = meanampDataset->SetMetadataItem("N", std::to_string(nbands).c_str(), NULL);
+
     //Close the datasets
     GDALClose(inDataset);
     GDALClose(daDataset);

--- a/src/ampdispersion/ampdispersion.cpp
+++ b/src/ampdispersion/ampdispersion.cpp
@@ -284,8 +284,8 @@ int ampdispersion_process(ampdispersionOptions *opts)
     std::cout << "ampdispersion processing time: " << (t_end-t_start)/60.0 << " mins \n";
 
     //Annotate the output datasets with number of SLCs/nbands used for future reference
-    status = daDataset->SetMetadataItem("N", std::to_string(nbands).c_str(), NULL);
-    status = meanampDataset->SetMetadataItem("N", std::to_string(nbands).c_str(), NULL);
+    status = daDataset->SetMetadataItem("N", std::to_string(nbands).c_str(), "ENVI");
+    status = meanampDataset->SetMetadataItem("N", std::to_string(nbands).c_str(), "ENVI");
 
     //Close the datasets
     GDALClose(inDataset);


### PR DESCRIPTION
this can be used for online updating of mean/amp dispersion